### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/foundry-tests.yml
+++ b/.github/workflows/foundry-tests.yml
@@ -89,6 +89,8 @@ jobs:
   static-analysis:
     name: Static Analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: backend/smart-contract


### PR DESCRIPTION
Potential fix for [https://github.com/irfndi/AetherDEX/security/code-scanning/5](https://github.com/irfndi/AetherDEX/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the `Static Analysis` job to explicitly define the minimal permissions required. Based on the steps in the job, it only needs `contents: read` to access the repository's files. This change will ensure that the `GITHUB_TOKEN` has the least privilege necessary to perform the job's tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
