### PR TITLE
Potential fix for code scanning alert no. 10: Useless conditional

### DIFF
--- a/interface/web/app/trade/swap/page.tsx
+++ b/interface/web/app/trade/swap/page.tsx
@@ -35,7 +35,7 @@ export default function SwapPage() {
     if (fromToken && toToken && value) {
       const fromValue = Number.parseFloat(value);
       let exchangeRate: number | undefined;
-      if (fromToken && toToken && fromToken.price !== undefined && toToken.price !== undefined) {
+      if (fromToken.price !== undefined && toToken.price !== undefined) {
         exchangeRate = fromToken.price / toToken.price;
         setToAmount((fromValue * exchangeRate).toFixed(6));
       } else {


### PR DESCRIPTION
Potential fix for [https://github.com/irfndi/AetherDEX/security/code-scanning/10](https://github.com/irfndi/AetherDEX/security/code-scanning/10)

To resolve the issue, remove the redundant condition `fromToken && toToken` from line 38, leaving only the essential checks for `fromToken.price !== undefined && toToken.price !== undefined`. This will simplify the conditional and align with best practices, avoiding unnecessary logic and improving code clarity. Only the relevant lines inside the `calculateToAmount` function, around line 38, need to be changed. No other code or imports need adjustment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
