### PR TITLE
Potential fix for code scanning alert no. 11: Useless conditional

### DIFF
--- a/interface/web/app/trade/swap/page.tsx
+++ b/interface/web/app/trade/swap/page.tsx
@@ -35,7 +35,7 @@ export default function SwapPage() {
     if (fromToken && toToken && value) {
       const fromValue = Number.parseFloat(value);
       let exchangeRate: number | undefined;
-      if (toToken && fromToken.price !== undefined && toToken.price !== undefined) {
+      if (fromToken.price !== undefined && toToken.price !== undefined) {
         exchangeRate = fromToken.price / toToken.price;
         setToAmount((fromValue * exchangeRate).toFixed(6));
       } else {

--- a/interface/web/app/trade/swap/page.tsx
+++ b/interface/web/app/trade/swap/page.tsx
@@ -35,7 +35,7 @@ export default function SwapPage() {
     if (fromToken && toToken && value) {
       const fromValue = Number.parseFloat(value);
       let exchangeRate: number | undefined;
-      if (fromToken && toToken && fromToken.price !== undefined && toToken.price !== undefined) {
+      if (toToken && fromToken.price !== undefined && toToken.price !== undefined) {
         exchangeRate = fromToken.price / toToken.price;
         setToAmount((fromValue * exchangeRate).toFixed(6));
       } else {


### PR DESCRIPTION
Potential fix for [https://github.com/irfndi/AetherDEX/security/code-scanning/11](https://github.com/irfndi/AetherDEX/security/code-scanning/11)

To resolve this warning, remove the redundant check for `fromToken` in the conditional on line 38 of `calculateToAmount`.  
**How:**  
- Change `if (fromToken && toToken && fromToken.price !== undefined && toToken.price !== undefined)`  
  to `if (toToken && fromToken.price !== undefined && toToken.price !== undefined)`
- No changes are needed elsewhere.
- Ensure surrounding logic remains correct (which it does, since `fromToken` is always present).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined swap calculation logic in the trade interface for improved code efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->