### PR TITLE
Potential fix for code scanning alert no. 12: Useless conditional

### DIFF
--- a/interface/web/app/trade/swap/page.tsx
+++ b/interface/web/app/trade/swap/page.tsx
@@ -35,7 +35,7 @@ export default function SwapPage() {
     if (fromToken && toToken && value) {
       const fromValue = Number.parseFloat(value);
       let exchangeRate: number | undefined;
-      if (fromToken && toToken && fromToken.price !== undefined && toToken.price !== undefined) {
+      if (fromToken.price !== undefined && toToken.price !== undefined) {
         exchangeRate = fromToken.price / toToken.price;
         setToAmount((fromValue * exchangeRate).toFixed(6));
       } else {


### PR DESCRIPTION
Potential fix for [https://github.com/irfndi/AetherDEX/security/code-scanning/12](https://github.com/irfndi/AetherDEX/security/code-scanning/12)

The best way to fix the problem is to remove the redundant checks for `fromToken` and `toToken` from the inner conditional on line 38, and only check for `fromToken.price !== undefined && toToken.price !== undefined`, since `fromToken` and `toToken` are guaranteed to be truthy due to the preceding guard. This preserves existing functionality while making the intent and logic clear. The edit should be limited to the `calculateToAmount` function, specifically lines 38-41.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
