### PR TITLE
Potential fix for code scanning alert no. 14: Useless conditional

### DIFF
--- a/interface/web/app/layout.tsx
+++ b/interface/web/app/layout.tsx
@@ -10,7 +10,7 @@ import { configureChains } from "@wagmi/core";
 import { polygonZkEvmTestnet } from "wagmi/chains";
 import { publicProvider } from "@wagmi/core/providers/public";
 
-const { chains, publicClient } = configureChains([polygonZkEvmTestnet], [publicProvider()]);
+const { chains } = configureChains([polygonZkEvmTestnet], [publicProvider()]);
 
 const config = createConfig({
   chains,
@@ -27,18 +27,18 @@ export const metadata = {
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  const [walletAddress, setWalletAddress] = useState("");
 
-  const handleWalletConnect = (address: string) => {
-    setWalletAddress(address);
-  };
+
+
+
+
 
   return (
     <html lang="en" suppressHydrationWarning className="dark">
       <body className={`${inter.className}`} style={{ backgroundColor: "lightblue" }}>
         <WagmiConfig config={config}>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-            <Header onWalletConnect={handleWalletConnect} />
+            <Header onWalletConnect={() => {}} />
             {children}
             <Toaster />
           </ThemeProvider>

--- a/interface/web/app/page.tsx
+++ b/interface/web/app/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
     if (fromToken && toToken && value) {
       const fromValue = Number.parseFloat(value);
       let exchangeRate: number | undefined;
-      if (fromToken && toToken && fromToken.price !== undefined && toToken.price !== undefined) {
+      if (toToken && fromToken.price !== undefined && toToken.price !== undefined) {
         exchangeRate = fromToken.price / toToken.price;
         setToAmount((fromValue * exchangeRate).toFixed(6));
       } else {

--- a/interface/web/app/page.tsx
+++ b/interface/web/app/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
     if (fromToken && toToken && value) {
       const fromValue = Number.parseFloat(value);
       let exchangeRate: number | undefined;
-      if (toToken && fromToken.price !== undefined && toToken.price !== undefined) {
+      if (fromToken.price !== undefined && toToken.price !== undefined) {
         exchangeRate = fromToken.price / toToken.price;
         setToAmount((fromValue * exchangeRate).toFixed(6));
       } else {
@@ -48,7 +48,6 @@ export default function Home() {
   const calculateFromAmount = (value: string) => {
     setToAmount(value);
     if (fromToken && toToken && value) {
-      const toValue = Number.parseFloat(value);
       let exchangeRate: number | undefined;
       if (toToken.price !== undefined && fromToken.price !== undefined) {
         exchangeRate = toToken.price / fromToken.price;

--- a/interface/web/app/trade/swap/page.tsx
+++ b/interface/web/app/trade/swap/page.tsx
@@ -35,7 +35,7 @@ export default function SwapPage() {
     if (fromToken && toToken && value) {
       const fromValue = Number.parseFloat(value);
       let exchangeRate: number | undefined;
-      if (fromToken && toToken && fromToken.price !== undefined && toToken.price !== undefined) {
+      if (fromToken.price !== undefined && toToken.price !== undefined) {
         exchangeRate = fromToken.price / toToken.price;
         setToAmount((fromValue * exchangeRate).toFixed(6));
       } else {


### PR DESCRIPTION
Potential fix for [https://github.com/irfndi/AetherDEX/security/code-scanning/14](https://github.com/irfndi/AetherDEX/security/code-scanning/14)

To fix this issue, remove the redundant `fromToken` check from the conditional at line 39 (`if (fromToken && toToken && fromToken.price !== undefined && toToken.price !== undefined)`). Since you already check for `fromToken` at line 36 (`if (fromToken && toToken && value)`), you can safely reduce line 39 to only check properties: `if (toToken && fromToken.price !== undefined && toToken.price !== undefined)`. However, given the context, the minimal fix is to remove `fromToken` from the line 39 check, leaving only `toToken && fromToken.price !== undefined && toToken.price !== undefined`.

Edit only the block containing this conditional (lines 36–44) in interface/web/app/page.tsx.

No imports, definitions, or new methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
