### PR TITLE
Potential fix for code scanning alert no. 15: Useless conditional

### DIFF
--- a/interface/web/app/page.tsx
+++ b/interface/web/app/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
     if (fromToken && toToken && value) {
       const fromValue = Number.parseFloat(value);
       let exchangeRate: number | undefined;
-      if (fromToken && toToken && fromToken.price !== undefined && toToken.price !== undefined) {
+      if (fromToken.price !== undefined && toToken.price !== undefined) {
         exchangeRate = fromToken.price / toToken.price;
         setToAmount((fromValue * exchangeRate).toFixed(6));
       } else {


### PR DESCRIPTION
Potential fix for [https://github.com/irfndi/AetherDEX/security/code-scanning/15](https://github.com/irfndi/AetherDEX/security/code-scanning/15)

To fix this problem, remove the redundant check for `fromToken` and `toToken` inside the condition at line 39. The outer if-statement at line 36 (`if (fromToken && toToken && value)`) already guarantees `fromToken` and `toToken` are defined and truthy within the block, so in line 39 the only necessary checks are whether `fromToken.price` and `toToken.price` are defined. 

Thus, in `interface/web/app/page.tsx`, revise line 39:
- Change
  ```ts
  if (fromToken && toToken && fromToken.price !== undefined && toToken.price !== undefined)
  ```
  to
  ```ts
  if (fromToken.price !== undefined && toToken.price !== undefined)
  ```
No additional imports, helpers, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
