### PR TITLE
Potential fix for code scanning alert no. 118: Invocation of non-function

### DIFF
--- a/apps/web/test/performance.bench.tsx
+++ b/apps/web/test/performance.bench.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, bench } from 'vitest'
 import { render } from '@testing-library/react'
 import { performance } from 'perf_hooks'
 import { TokenSelector } from '../components/features/trade/TokenSelector'
-import { createMockToken } from './setup'
+import createMockToken from './setup'
 
 // Mock SwapInterface component since it doesn't exist yet
 const SwapInterface = () => {

--- a/apps/web/test/performance.bench.tsx
+++ b/apps/web/test/performance.bench.tsx
@@ -3,9 +3,6 @@ import { describe, it, expect, bench } from 'vitest'
 import { render } from '@testing-library/react'
 import { performance } from 'perf_hooks'
 import { TokenSelector } from '../components/features/trade/TokenSelector'
-import createMockToken from './setup'
-
-// Mock SwapInterface component since it doesn't exist yet
 const SwapInterface = () => {
   return (
     <div data-testid="swap-interface">


### PR DESCRIPTION
Potential fix for [https://github.com/irfndi/AetherDEX/security/code-scanning/118](https://github.com/irfndi/AetherDEX/security/code-scanning/118)

To fix this problem, `createMockToken` must be a function imported from `'./setup'`. This means that you need to ensure it is actually exported as a function from the appropriate module, and that the import statement matches the export. Sometimes, the function may be exported as a named export or as a default export, and using the wrong form in the import can lead to `undefined` at runtime.

Specifically:
- Verify that `createMockToken` is exported in `'./setup'`, e.g., `export function createMockToken(...) { ... }` or `export default function createMockToken(...) { ... }`.
- If `createMockToken` is the default export, use `import createMockToken from './setup'`.
- If it is a named export, keep using `import { createMockToken } from './setup'`.
- Check/correct the import statement in `apps/web/test/performance.bench.tsx` (line 6), updating it as needed.

No further code edits are necessary unless the import is corrected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure with internal refactoring to improve code organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->