### PR TITLE
feat: Implement addLiquidity in AetherRouter

### DIFF
--- a/backend/smart-contract/src/interfaces/IAetherPool.sol
+++ b/backend/smart-contract/src/interfaces/IAetherPool.sol
@@ -83,4 +83,16 @@ interface IAetherPool {
     /// @notice Returns the current fee for the pool.
     /// @return fee The current pool fee.
     function fee() external view returns (uint24 fee);
+
+    /// @notice Returns the reserve of token0.
+    /// @return reserve0 The reserve of token0.
+    function reserve0() external view returns (uint256 reserve0);
+
+    /// @notice Returns the reserve of token1.
+    /// @return reserve1 The reserve of token1.
+    function reserve1() external view returns (uint256 reserve1);
+
+    /// @notice Returns the total supply of liquidity tokens.
+    /// @return totalSupply The total supply of liquidity tokens.
+    function totalSupply() external view returns (uint256 totalSupply);
 }

--- a/backend/smart-contract/test/AetherRouter.t.sol
+++ b/backend/smart-contract/test/AetherRouter.t.sol
@@ -18,6 +18,7 @@ import {MockCCIPRouter} from "./mocks/MockCCIPRouter.sol";
 import {MockHyperlane} from "./mocks/MockHyperlane.sol";
 import {console} from "forge-std/console.sol";
 import {PoolKey} from "../src/types/PoolKey.sol";
+import {MockAetherPool} from "./mocks/MockAetherPool.sol";
 
 contract AetherRouterTest is Test {
     AetherRouter public router;
@@ -35,201 +36,112 @@ contract AetherRouterTest is Test {
     address public alice = address(0x1);
     address public bob = address(0x2);
 
-    // Helper function to create PoolKey and calculate poolId
-    function _createPoolKeyAndId(address token0, address token1, uint24 fee, int24 tickSpacing, address hooks)
-        internal
-        pure
-        returns (PoolKey memory key, bytes32 poolId)
-    {
-        require(token0 < token1, "UNSORTED_TOKENS");
-        key = PoolKey({token0: token0, token1: token1, fee: fee, tickSpacing: tickSpacing, hooks: hooks});
-        poolId = keccak256(abi.encode(key));
-    }
-
     function setUp() public {
-        console.log("Starting setUp...");
-        console.log("Test Contract Address (this):", address(this));
-        // Deploy FeeRegistry
-        // console.log("Deploying FeeRegistry with owner:", address(this));
-        // feeRegistry = new FeeRegistry(address(this)); // Pass initialOwner - FeeRegistry is abstract
-        // console.log("FeeRegistry deployed at:", address(feeRegistry));
-        // console.log("FeeRegistry actual owner:", feeRegistry.owner());
-        // Add the default fee tier configuration used in tests (using 0.3% fee)
-        // console.log("Adding fee tier 300 with tick spacing 60 to FeeRegistry...");
-        // feeRegistry.addFeeConfiguration(300, 60); // Use 300 (0.3%) instead of 3000 (30%)
-        // console.log("Fee tier added.");
-
         // Deploy tokens
-        console.log("Deploying tokens...");
         weth = new MockERC20("Wrapped ETH", "WETH", 18);
         usdc = new MockERC20("USD Coin", "USDC", 6);
         dai = new MockERC20("DAI", "DAI", 18);
-        console.log("Tokens deployed.");
 
-        // Deploy factory and router
-        console.log("Deploying factory...");
-        factory = new AetherFactory(address(this), address(feeRegistry), 3000); // Pass owner, feeRegistry, and initial pool fee of 0.3%
-        console.log("Factory deployed at:", address(factory));
-        // Deploy MockPoolManager
-        console.log("Deploying MockPoolManager...");
-        // Pass hook address (using address(0) as placeholder)
-        mockPoolManager = new MockPoolManager(address(0));
-        console.log("MockPoolManager deployed at:", address(mockPoolManager));
-        // Deploy router with mock cross-chain contracts
-        console.log("Deploying mock cross-chain contracts...");
-        ccipRouter = address(new MockCCIPRouter());
-        hyperlane = address(new MockHyperlane());
-        linkToken = address(new MockERC20("LINK", "LINK", 18));
-        console.log("Mock contracts deployed.");
-        console.log("Deploying router with owner:", address(this));
-        // Deploy router with required constructor args
-        router = new AetherRouter(); // Default constructor takes no arguments
-        console.log("Router deployed at:", address(router));
+        // Deploy router
+        router = new AetherRouter();
 
-        // Create pools with proper token ordering
-        console.log("Deploying and registering WETH/USDC pool (placeholder)...");
-        address wethUsdcPool = address(0x1); // Placeholder: Deploy Vyper pool via vm.deployCode
-        factory.registerPool(wethUsdcPool, address(weth), address(usdc));
-        console.log("WETH/USDC Pool registered:", wethUsdcPool);
+        // Mint tokens to this contract
+        weth.mint(address(this), 10000 ether);
+        usdc.mint(address(this), 10000000 * 1e6);
+        dai.mint(address(this), 10000000 ether);
 
-        console.log("Deploying and registering WETH/DAI pool (placeholder)...");
-        address wethDaiPool = address(0x2); // Placeholder: Deploy Vyper pool via vm.deployCode
-        factory.registerPool(wethDaiPool, address(weth), address(dai));
-        console.log("WETH/DAI Pool registered:", wethDaiPool);
+        // Deploy Mock Pool
+        // Ensure token order
+        address token0 = address(weth) < address(usdc) ? address(weth) : address(usdc);
+        address token1 = address(weth) < address(usdc) ? address(usdc) : address(weth);
+        pool = new MockAetherPool(token0, token1, 3000);
 
-        // Mint tokens to test contract first before approvals
-        console.log("Minting initial tokens to test contract...");
-        weth.mint(address(this), 10_000 ether); // Keep 10k WETH
-        usdc.mint(address(this), 20_000_000 * 1e6); // Mint 20M USDC (10M for each pool)
-        dai.mint(address(this), 10_000_000 ether); // Keep 10M DAI
-        console.log("Initial tokens minted.");
-        console.log("WETH balance:", weth.balanceOf(address(this)));
-        console.log("USDC balance:", usdc.balanceOf(address(this)));
-        console.log("DAI balance:", dai.balanceOf(address(this)));
-
-        // Approve sufficient allowance for router with explicit amounts
-        console.log("Approving router...");
-        uint256 maxAmount = type(uint256).max;
-        weth.approve(address(router), maxAmount);
-        usdc.approve(address(router), maxAmount);
-        dai.approve(address(router), maxAmount);
-        console.log("Router approved.");
-
-        // Add initial liquidity to pools with explicit approvals, balancing for decimals
-        console.log("Adding liquidity to WETH/USDC pool...");
-        // Assuming 1 WETH = $2000, 1 USDC = $1. Provide $10M liquidity.
-        // 5000 WETH = $10M
-        // 10,000,000 USDC = $10M
-        _addLiquidityToPoolWithApprovals(
-            wethUsdcPool,
-            address(weth),
-            5_000 ether, // 5000 * 1e18 WETH
-            address(usdc),
-            10_000_000 * 1e6, // 10M * 1e6 USDC
-            maxAmount
-        );
-        console.log("Liquidity added to WETH/USDC pool.");
-        console.log("WETH balance after liq1:", weth.balanceOf(address(this)));
-        console.log("USDC balance after liq1:", usdc.balanceOf(address(this)));
-
-        console.log("Adding liquidity to USDC/DAI pool...");
-        // Provide $10M liquidity (assuming 1 USDC = 1 DAI = $1)
-        _addLiquidityToPoolWithApprovals(
-            wethDaiPool, // Use wethDaiPool address for the second pool setup
-            address(usdc),
-            10_000_000 * 1e6, // 10M * 1e6 USDC
-            address(dai),
-            10_000_000 ether, // 10M * 1e18 DAI
-            maxAmount
-        );
-        console.log("Liquidity added to USDC/DAI pool.");
-        console.log("USDC balance after liq2:", usdc.balanceOf(address(this)));
-        console.log("DAI balance after liq2:", dai.balanceOf(address(this)));
-
-        // Verify balances after setup (USDC should be 0 after providing liquidity)
-        console.log("Verifying final balances...");
-        // Check remaining balances after providing liquidity
-        require(weth.balanceOf(address(this)) == 5_000 ether, "Incorrect WETH balance after setup"); // 10k - 5k = 5k
-        require(usdc.balanceOf(address(this)) == 0, "Incorrect USDC balance after setup"); // 20M - 10M - 10M = 0
-        require(dai.balanceOf(address(this)) == 0, "Incorrect DAI balance after setup"); // 10M - 10M = 0
-        console.log("Final balances verified.");
-
-        // Fund test accounts
-        console.log("Funding test accounts...");
-        vm.deal(alice, 100 ether);
-        weth.mint(alice, 100 ether);
-        usdc.mint(alice, 100_000 * 1e6);
-        dai.mint(alice, 100_000 ether);
-        console.log("Alice funded.");
-
-        // Approve router for test accounts
-        console.log("Approving router for Alice...");
-        vm.startPrank(alice);
+        // Approve router
         weth.approve(address(router), type(uint256).max);
         usdc.approve(address(router), type(uint256).max);
         dai.approve(address(router), type(uint256).max);
-        vm.stopPrank();
-        console.log("Router approved for Alice.");
-
-        console.log("Funding Bob...");
-        vm.deal(bob, 100 ether);
-        weth.mint(bob, 100 ether);
-        usdc.mint(bob, 100_000 * 1e6);
-        dai.mint(bob, 100_000 ether);
-        console.log("Bob funded.");
-        console.log("setUp finished.");
     }
 
-    // Updated helper to handle token ordering correctly
-    function _addLiquidityToPoolWithApprovals(
-        address poolAddress,
-        address tokenA,
-        uint256 amountA, // Pass actual tokens and amounts
-        address tokenB,
-        uint256 amountB,
-        uint256 approvalAmount // Use a single approval amount for simplicity (max uint)
-    ) internal {
-        require(poolAddress != address(0), "Pool not found");
-        // IAetherPool pool = IAetherPool(poolAddress); // Commented out shadowed variable
+    function test_addLiquidity_Initial() public {
+        (address token0, address token1) = pool.tokens();
 
-        // address poolToken0 = IAetherPool(poolAddress).token0(); // Incorrect: IAetherPool has tokens()
-        // address poolToken1 = IAetherPool(poolAddress).token1(); // Incorrect: IAetherPool has tokens()
-        (address poolToken0, address poolToken1) = IAetherPool(poolAddress).tokens();
+        uint256 amount0Desired;
+        uint256 amount1Desired;
 
-        // Determine the correct amounts based on the pool's token order
-        uint256 amount0ForPool;
-        uint256 amount1ForPool;
-
-        if (tokenA == poolToken0 && tokenB == poolToken1) {
-            amount0ForPool = amountA;
-            amount1ForPool = amountB;
-        } else if (tokenA == poolToken1 && tokenB == poolToken0) {
-            amount0ForPool = amountB;
-            amount1ForPool = amountA;
+        if (token0 == address(weth)) {
+            amount0Desired = 100 ether;
+            amount1Desired = 200_000 * 1e6;
         } else {
-            revert("Helper token mismatch"); // Should not happen if poolId is correct
+            amount0Desired = 200_000 * 1e6;
+            amount1Desired = 100 ether;
         }
 
-        // Tokens should already be minted in setUp to address(this)
+        uint256 amount0Min = amount0Desired * 90 / 100;
+        uint256 amount1Min = amount1Desired * 90 / 100;
+        uint256 deadline = block.timestamp + 100;
 
-        // Approve the pool to take the tokens from this contract (address(this))
-        // Use the pool's actual token0 and token1 for approval targets
-        console.log("Approving pool %s for token0 %s amount %s", poolAddress, poolToken0, approvalAmount);
-        MockERC20(poolToken0).approve(poolAddress, approvalAmount);
-        console.log("Approving pool %s for token1 %s amount %s", poolAddress, poolToken1, approvalAmount);
-        MockERC20(poolToken1).approve(poolAddress, approvalAmount);
-        console.log("Pool approved for both tokens.");
-
-        // Call mint with the correctly ordered amounts
-        console.log(
-            "Calling pool.mint for pool %s with amount0 %s, amount1 %s", poolAddress, amount0ForPool, amount1ForPool
+        (uint256 amountA, uint256 amountB, uint256 liquidity) = router.addLiquidity(
+            address(pool),
+            amount0Desired,
+            amount1Desired,
+            amount0Min,
+            amount1Min,
+            address(this),
+            deadline
         );
-        // TODO: Add liquidity via PoolManager or update test logic
-        // IAetherPool(poolAddress).mint(address(this), amount0ForPool, amount1ForPool); // Old incompatible call
-        console.log("pool.mint called successfully.");
+
+        // Check liquidity
+        assertGt(liquidity, 0, "Liquidity should be minted");
+        assertEq(amountA, amount0Desired, "Should use all desired amountA for initial");
+        assertEq(amountB, amount1Desired, "Should use all desired amountB for initial");
+
+        // Check pool reserves (MockAetherPool specific)
+        assertGt(pool.reserve0(), 0, "Reserve0 should be > 0");
+        assertGt(pool.reserve1(), 0, "Reserve1 should be > 0");
     }
 
-    // function test_SwapWithMultipleHops() public {
-    //     // Test swapping WETH -> DAI -> USDC
-    // }
+    function test_addLiquidity_Subsequent() public {
+        // First add initial liquidity
+        test_addLiquidity_Initial();
+
+        uint256 initialLiquidity = MockAetherPool(address(pool)).liquidityOf(address(this));
+        uint256 initialReserve0 = pool.reserve0();
+        uint256 initialReserve1 = pool.reserve1();
+
+        (address token0, ) = pool.tokens();
+
+        uint256 amount0Desired;
+        uint256 amount1Desired;
+
+        // Add same ratio
+        if (token0 == address(weth)) {
+            amount0Desired = 100 ether;
+            amount1Desired = 200_000 * 1e6;
+        } else {
+            amount0Desired = 200_000 * 1e6;
+            amount1Desired = 100 ether;
+        }
+
+        uint256 amount0Min = amount0Desired * 90 / 100;
+        uint256 amount1Min = amount1Desired * 90 / 100;
+        uint256 deadline = block.timestamp + 100;
+
+        (uint256 amountA, uint256 amountB, uint256 liquidity) = router.addLiquidity(
+            address(pool),
+            amount0Desired,
+            amount1Desired,
+            amount0Min,
+            amount1Min,
+            address(this),
+            deadline
+        );
+
+        // Check liquidity
+        assertGt(liquidity, 0, "Liquidity should be minted");
+        assertEq(amountA, amount0Desired, "Should use all desired amountA for subsequent");
+        assertEq(amountB, amount1Desired, "Should use all desired amountB for subsequent");
+
+        // Verify total liquidity increased
+        assertGt(MockAetherPool(address(pool)).liquidityOf(address(this)), initialLiquidity, "Total liquidity should increase");
+    }
 }

--- a/backend/smart-contract/test/SwapRouter.t.sol
+++ b/backend/smart-contract/test/SwapRouter.t.sol
@@ -182,6 +182,18 @@ contract MockPool is IAetherPool {
         return liquidityOut;
     }
 
+    function reserve0() external pure returns (uint256) {
+        return 1000 ether; // Mock implementation
+    }
+
+    function reserve1() external pure returns (uint256) {
+        return 1000 ether; // Mock implementation
+    }
+
+    function totalSupply() external pure returns (uint256) {
+        return 2000 ether; // Mock implementation
+    }
+
     // Implement other IAetherPool functions if they become necessary for tests, possibly with reverts or default values.
     // --- End IAetherPool Implementation ---
 }

--- a/backend/smart-contract/test/integration/FeatureIntegration.t.sol
+++ b/backend/smart-contract/test/integration/FeatureIntegration.t.sol
@@ -127,6 +127,19 @@ contract MockPool is IAetherPool {
         }
         return liquidityOut;
     }
+
+    function reserve0() external pure returns (uint256) {
+        return 1000 ether; // Mock implementation
+    }
+
+    function reserve1() external pure returns (uint256) {
+        return 1000 ether; // Mock implementation
+    }
+
+    function totalSupply() external pure returns (uint256) {
+        return 2000 ether; // Mock implementation
+    }
+
     // Placeholder for initialize if needed by IPoolManager interactions
     function initialize(address /*_token0*/, address /*_token1*/, uint24 /*_fee*/) external override {
         // This function is required by IAetherPool.


### PR DESCRIPTION
This pull request implements and tests the full add liquidity flow for the `AetherRouter`, including optimal amount calculation, token transfers, and integration with pool contracts. It also expands the `IAetherPool` interface and updates mocks and tests to support reserve and supply queries.

**Router logic and liquidity flow:**
- Implemented optimal liquidity addition in `AetherRouter.addLiquidity`, including helper functions for square root, min, and optimal amount calculation, as well as proper token transfer and interaction with pool contracts for both initial and subsequent liquidity provision. [[1]](diffhunk://#diff-f26eb4af4535250b72b91b3c1cb0950114640f1aefab182520ac89aef565dbb4R25-R67) [[2]](diffhunk://#diff-f26eb4af4535250b72b91b3c1cb0950114640f1aefab182520ac89aef565dbb4L35-L54)

**Interface and mock updates:**
- Extended `IAetherPool` with new view functions to return `reserve0`, `reserve1`, and `totalSupply`, supporting more accurate router logic and testing.
- Updated pool mocks (`MockPool`, `MockAetherPool`) to implement the new reserve and supply interface, enabling realistic testing of router behavior. [[1]](diffhunk://#diff-44ab902e9de4b58fe02c749512c520b874140d938a9e249dc64eed4ee400e350R185-R196) [[2]](diffhunk://#diff-5f6575fc971d67df182fbd34fd50938cc75f7fcd3043a63b627a93764026b063R130-R142) [[3]](diffhunk://#diff-25a8ed82f5edeb4925bbb399e5d241e107fb8754d7004fbd19fdac44fc7cb6e6R16-R19)

**Testing improvements:**
- Refactored `AetherRouter.t.sol` setup for clarity and reliability, deploying a real `MockAetherPool`, minting tokens, and adding comprehensive tests for both initial and subsequent liquidity additions. [[1]](diffhunk://#diff-f4da3cfc763c0526f3567be71185a16b6b9965333fa8cad62388e187142be948R21) [[2]](diffhunk://#diff-f4da3cfc763c0526f3567be71185a16b6b9965333fa8cad62388e187142be948L38-R146)- Implemented `addLiquidity` in `AetherRouter.sol` with optimal amount calculation and slippage checks.
- Handled initial liquidity addition via `addInitialLiquidity` and subsequent via `mint`.
- Optimized gas usage by only approving tokens for initial liquidity (subsequent handled by direct transfer).
- Updated `IAetherPool.sol` interface to include `reserve0`, `reserve1`, and `totalSupply`.
- Updated `MockAetherPool.sol` to correctly track reserves and align with `AetherPool.vy` behavior (no token pulling in `mint`).
- Added comprehensive tests in `AetherRouter.t.sol` for initial and subsequent liquidity addition.
- Removed junk files.

## Description

<!-- Describe the changes made and why they were made -->

## Related Issues

<!-- Reference any related issues (e.g., "Fixes #123", "Addresses #456") -->

## Changes

<!-- Detail the key changes in bullet points -->

-
-

## Testing

<!-- Describe how these changes were tested -->

## Screenshots

<!-- If applicable, add screenshots to demonstrate the changes -->

## Checklist

- [ ] Code follows the project's style guidelines
- [ ] Code has been self-reviewed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests for the changes have been added/updated
- [ ] Documentation has been updated (if applicable)
