### PR TITLE
ci: modernize CI/CD — strict gates, caching, path filters, SHA pinning, Renovate, hardening (Workstream C)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,38 @@
+# Composite action: single source of truth for "make this repo runnable" in CI.
+# Steps: checkout -> Node 24 -> Bun canary -> restore bun cache -> bun install (frozen).
+#
+# Every third-party action is pinned to a full commit SHA. The trailing `# vN` comment
+# records the floating tag the SHA was resolved from; Renovate (renovate.json) updates
+# the SHAs automatically while we stay supply-chain safe.
+name: "Setup workspace"
+description: "Checkout, install Node 24 + Bun canary, restore the bun cache, and install dependencies with a frozen lockfile."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+    - name: Set up Node
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      with:
+        node-version: "24"
+
+    - name: Set up Bun (canary)
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      with:
+        bun-version: canary
+
+    # Warm the Bun package cache. The monorepo has a single root `bun.lock`, so a
+    # single cache key is correct and shared across all jobs.
+    - name: Cache bun install cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: ~/.bun/install/cache
+        key: ${{ runner.os }}-bun-${{ hashFiles("bun.lock") }}
+        restore-keys: |
+          ${{ runner.os }}-bun-
+
+    - name: Install dependencies
+      shell: bash
+      run: bun install --frozen-lockfile

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,18 +1,19 @@
 # Composite action: single source of truth for "make this repo runnable" in CI.
-# Steps: checkout -> Node 24 -> Bun canary -> restore bun cache -> bun install (frozen).
+# Steps: Node 24 -> Bun canary -> restore bun cache -> bun install (frozen).
+#
+# Platform constraint: a local composite action cannot load before the repo is on disk,
+# so checking out here would break every job (actions/checkout cannot bootstrap the
+# action that contains it). Callers MUST run actions/checkout first, then this action.
 #
 # Every third-party action is pinned to a full commit SHA. The trailing `# vN` comment
 # records the floating tag the SHA was resolved from; Renovate (renovate.json) updates
 # the SHAs automatically while we stay supply-chain safe.
 name: "Setup workspace"
-description: "Checkout, install Node 24 + Bun canary, restore the bun cache, and install dependencies with a frozen lockfile."
+description: "Install Node 24 + Bun canary, restore the bun cache, and install dependencies with a frozen lockfile. Requires actions/checkout to have run first."
 
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
     - name: Set up Node
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
@@ -29,7 +30,9 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: ~/.bun/install/cache
-        key: ${{ runner.os }}-bun-${{ hashFiles("bun.lock") }}
+        # GitHub Actions expressions require single-quoted string literals inside
+        # hashFiles(); double quotes break the workflow.
+        key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
         restore-keys: |
           ${{ runner.os }}-bun-
 

--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -4,6 +4,9 @@ paths:
   - "apps/**"
   - "packages/contracts/src/**"
   - "packages/contracts/test/**"
+  # Let the `actions` CodeQL language scan our workflows + composite action.
+  - ".github/workflows/**"
+  - ".github/actions/**"
 
 paths-ignore:
   - "**/routeTree.gen.ts"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,25 @@
+# Dependabot is RETAINED ONLY as a security-update fallback. Renovate owns all routine
+# dependency automation (npm/bun + github-actions) via renovate.json / renovate.yml.
+#
+# Why not per-directory npm version updates here? The monorepo uses a SINGLE root
+# bun.lock (Bun workspaces). Dependabot cannot read bun.lock and its root + /apps/web +
+# /apps/api npm entries produced conflicting, stormy PRs that all fight over the same
+# files. Those entries have been removed.
+#
+# `open-pull-requests-limit: 0` disables routine VERSION-update PRs while still letting
+# Dependabot open SECURITY-update PRs for GitHub Security Advisories (security updates
+# ignore this limit). This keeps a second, independent vulnerability layer alongside
+# Renovate's own `vulnerabilityAlerts`.
 version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      bun-and-ts:
-        patterns:
-          - "bun*"
-          - "@biomejs/*"
-          - "typescript"
-          - "@typescript/*"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "npm"
-    directory: "/apps/web"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "npm"
-    directory: "/apps/api"
-    schedule:
-      interval: "weekly"
+    open-pull-requests-limit: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,8 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup workspace
         uses: ./.github/actions/setup
       - name: Typecheck
@@ -117,6 +119,8 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup workspace
         uses: ./.github/actions/setup
 
@@ -126,7 +130,9 @@ jobs:
           version: ${{ env.FOUNDRY_VERSION }}
 
       # Cache the (otherwise uncommitted) Foundry libs and build artifacts so we do not
-      # re-clone v4-core / forge-std / OZ and recompile on every run.
+      # re-clone v4-core / forge-std / OZ and recompile on every run. The key also hashes
+      # this workflow because the pinned forge-install revisions live here, so bumping a
+      # dependency invalidates the cache instead of silently reusing stale libs.
       - name: Cache Foundry libs + build artifacts
         id: foundry-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
@@ -135,7 +141,7 @@ jobs:
             packages/contracts/lib
             packages/contracts/out
             packages/contracts/cache
-          key: ${{ runner.os }}-foundry-${{ env.FOUNDRY_VERSION }}-${{ hashFiles('packages/contracts/foundry.toml', 'packages/contracts/remappings.txt') }}
+          key: ${{ runner.os }}-foundry-${{ env.FOUNDRY_VERSION }}-${{ hashFiles('packages/contracts/foundry.toml', 'packages/contracts/remappings.txt', '.github/workflows/ci.yml') }}
           restore-keys: |
             ${{ runner.os }}-foundry-${{ env.FOUNDRY_VERSION }}-
 
@@ -250,6 +256,8 @@ jobs:
       run:
         working-directory: apps/api
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup workspace
         uses: ./.github/actions/setup
 
@@ -314,6 +322,8 @@ jobs:
       run:
         working-directory: apps/web
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup workspace
         uses: ./.github/actions/setup
 
@@ -356,6 +366,8 @@ jobs:
       run:
         working-directory: apps/web
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup workspace
         uses: ./.github/actions/setup
 
@@ -381,11 +393,16 @@ jobs:
           if-no-files-found: ignore
 
   # ---------------------------------------------------------------------------
-  # Echidna fuzzing (advisory). Real tooling is installed and run, but the existing
-  # suite is Foundry-style invariant fuzzing, not Echidna property/assertion harnesses.
-  # Promoting to a hard gate needs an Echidna config + `echidna_*` properties (owned by
-  # the contracts workstream, out of scope here) — so it is continue-on-error and is
-  # NOT part of the ci-status gate.
+  # Echidna fuzzing (advisory). Only fuzzes a REAL harness when one exists.
+  #
+  # Echidna cannot fuzz `src/hook/AetherHook.sol` directly: its 4-arg constructor rejects
+  # the default zero treasury and validates its own address's BEFORE_SWAP|AFTER_SWAP hook
+  # bits, so a default deployment fails before any case runs. We do NOT `continue-on-error`
+  # over that. Instead this job looks for a property harness under
+  # packages/contracts/test/echidna/ (an `echidna.yaml` + a .sol harness exposing
+  # `echidna_*` invariants, deploying AetherHook at a bit-mined CREATE2 address). Present
+  # -> fuzz for real; absent -> SKIP transparently (message + clean exit). Landing the
+  # harness (owned by the contracts workstream) auto-enables this job.
   # ---------------------------------------------------------------------------
   echidna:
     name: Echidna fuzz — advisory
@@ -394,19 +411,40 @@ jobs:
     if: ${{ github.event_name == 'schedule' || needs.detect-changes.outputs.contracts == 'true' }}
     permissions:
       contents: read
-    continue-on-error: true
     env:
       ECHIDNA_VERSION: v2.3.2
+      ECHIDNA_DIR: packages/contracts/test/echidna
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Decide up front whether a real harness exists. Everything heavy below is gated on
+      # this so an absent harness skips fast and loudly rather than pretending to fuzz.
+      - name: Detect Echidna harness
+        id: harness
+        run: |
+          set -euo pipefail
+          if [ -f "${ECHIDNA_DIR}/echidna.yaml" ] && ls "${ECHIDNA_DIR}"/*.sol >/dev/null 2>&1; then
+            echo "present=true" >> "${GITHUB_OUTPUT}"
+            echo "Echidna harness found under ${ECHIDNA_DIR}; will fuzz."
+          else
+            echo "present=false" >> "${GITHUB_OUTPUT}"
+            echo "SKIPPED: no echidna harness yet (tracked as future work)."
+            echo "Expected ${ECHIDNA_DIR}/echidna.yaml + a .sol property harness; adding them auto-enables this job."
+          fi
+
       - name: Setup workspace
+        if: steps.harness.outputs.present == 'true'
         uses: ./.github/actions/setup
 
       - name: Install Foundry (pinned)
+        if: steps.harness.outputs.present == 'true'
         uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1
         with:
           version: ${{ env.FOUNDRY_VERSION }}
 
       - name: Cache Foundry libs + build artifacts
+        if: steps.harness.outputs.present == 'true'
         id: echidna-foundry-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
@@ -414,12 +452,12 @@ jobs:
             packages/contracts/lib
             packages/contracts/out
             packages/contracts/cache
-          key: ${{ runner.os }}-foundry-${{ env.FOUNDRY_VERSION }}-${{ hashFiles('packages/contracts/foundry.toml', 'packages/contracts/remappings.txt') }}
+          key: ${{ runner.os }}-foundry-${{ env.FOUNDRY_VERSION }}-${{ hashFiles('packages/contracts/foundry.toml', 'packages/contracts/remappings.txt', '.github/workflows/ci.yml') }}
           restore-keys: |
             ${{ runner.os }}-foundry-${{ env.FOUNDRY_VERSION }}-
 
       - name: Install contract libs (pinned, cache-miss only)
-        if: steps.echidna-foundry-cache.outputs.cache-hit != 'true'
+        if: steps.harness.outputs.present == 'true' && steps.echidna-foundry-cache.outputs.cache-hit != 'true'
         working-directory: packages/contracts
         run: |
           set -euo pipefail
@@ -429,10 +467,12 @@ jobs:
           forge install OpenZeppelin/openzeppelin-contracts@v5.5.0 --no-git
 
       - name: Build contracts
+        if: steps.harness.outputs.present == 'true'
         working-directory: packages/contracts
         run: forge build --via-ir
 
       - name: Install Echidna + solc
+        if: steps.harness.outputs.present == 'true'
         run: |
           set -euo pipefail
           # Official static linux binary (x86_64) for Ubuntu runners.
@@ -445,18 +485,14 @@ jobs:
           solc-select install 0.8.31
           solc-select use 0.8.31
 
-      - name: Run Echidna (assertion mode)
+      - name: Run Echidna (property harness)
+        if: steps.harness.outputs.present == 'true'
         working-directory: packages/contracts
         run: |
           set -euo pipefail
-          # Compile + fuzz the hook's bytecode for assertion violations. Crytic-compile
-          # auto-detects foundry.toml for import/remapping resolution. A dedicated
-          # Echidna config + property harness will sharpen and eventually gate this.
-          echidna src/hook/AetherHook.sol \
-            --contract AetherHook \
-            --test-mode assertion \
-            --corpus-dir /tmp/echidna-corpus \
-            --test-limit 50000
+          # Fuzz the real harness via its config. Crytic-compile runs on the project root
+          # (.) so it reads foundry.toml for import/remapping resolution.
+          echidna . --config test/echidna/echidna.yaml --corpus-dir /tmp/echidna-corpus
 
   # ---------------------------------------------------------------------------
   # Required status gate. Required jobs must be success or skipped (path-filtered out);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,146 +5,502 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  # Echidna fuzzing runs on a weekly schedule (and on contract changes); every other
+  # job opts out of scheduled runs.
+  schedule:
+    - cron: "30 5 * * 1" # Weekly, Monday 05:30 UTC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Deny-by-default: every job inherits read-only contents unless it declares more.
+permissions:
+  contents: read
+
+env:
+  # Pin Foundry to a reproducible release (matches the toolchain developers run locally).
+  FOUNDRY_VERSION: v1.7.1
+
 jobs:
-  contracts:
-    name: Contracts (Foundry)
+  # ---------------------------------------------------------------------------
+  # Change detection (path filters). Speeds CI by skipping untouched workspaces.
+  # ---------------------------------------------------------------------------
+  detect-changes:
+    name: Detect changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read # dorny/paths-filter reads PR file lists on pull_request
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      contracts: ${{ steps.filter.outputs.contracts }}
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
     steps:
-      - uses: actions/checkout@v7
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: foundry-rs/foundry-toolchain@v1
-      - uses: actions/setup-node@v7
+      - name: Filter by changed paths
+        if: ${{ github.event_name != 'schedule' }}
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+        id: filter
         with:
-          node-version: "24"
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: canary
-      - name: Install deps
-        run: bun install --frozen-lockfile
-      - name: Install forge dependencies
-        working-directory: packages/contracts
-        run: |
-          forge install foundry-rs/forge-std --no-git --shallow
-          forge install Uniswap/v4-core --no-git --shallow
-          forge install OpenZeppelin/openzeppelin-contracts@v5.5.0 --no-git --shallow
-      - name: Build contracts
-        working-directory: packages/contracts
-        run: forge build --via-ir
-      - name: Run tests
-        working-directory: packages/contracts
-        run: forge test -vvv
-      - name: Coverage
-        working-directory: packages/contracts
-        run: forge coverage --report summary --ir-minimum
-        continue-on-error: true
-      - name: Slither static analysis
-        working-directory: packages/contracts
-        run: |
-          if command -v slither &> /dev/null; then
-            slither . --filter-paths "lib/|test/" || true
-          else
-            echo "Slither not installed, skipping"
-          fi
-        continue-on-error: true
-      - name: Upload coverage
-        if: always()
-        uses: codecov/codecov-action@v7
-        with:
-          files: packages/contracts/coverage.lcov
-          flags: contracts
-          fail_ci_if_error: false
+          # Shared/root changes that can affect any workspace.
+          filters: |
+            code:
+              - 'src/**'
+              - 'tooling/**'
+              - 'apps/**'
+              - 'packages/**'
+              - 'package.json'
+              - 'bun.lock'
+              - 'tsconfig.json'
+              - 'apps/**/tsconfig.json'
+              - 'biome.json'
+              - 'vitest.config.ts'
+              - '.github/actions/**'
+              - '.github/workflows/ci.yml'
+            contracts:
+              - 'packages/contracts/**'
+              - 'package.json'
+              - 'bun.lock'
+              - '.github/actions/**'
+              - '.github/workflows/ci.yml'
+            backend:
+              - 'apps/api/**'
+              - 'package.json'
+              - 'bun.lock'
+              - 'tsconfig.json'
+              - 'biome.json'
+              - 'vitest.config.ts'
+              - '.github/actions/**'
+              - '.github/workflows/ci.yml'
+            frontend:
+              - 'apps/web/**'
+              - 'package.json'
+              - 'bun.lock'
+              - 'tsconfig.json'
+              - 'biome.json'
+              - 'vitest.config.ts'
+              - '.github/actions/**'
+              - '.github/workflows/ci.yml'
 
-  backend:
-    name: Backend (Workers + Effect)
+  # ---------------------------------------------------------------------------
+  # Fast quality gate: workspace typecheck + repo-wide Biome lint.
+  # Runs on any code change. (Root tsconfig excludes apps/**, so the per-workspace
+  # typechecks below cover the apps.)
+  # ---------------------------------------------------------------------------
+  quality:
+    name: Typecheck + Lint
     runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ github.event_name != 'schedule' && needs.detect-changes.outputs.code == 'true' }}
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "24"
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: canary
-      - name: Install deps
-        run: bun install --frozen-lockfile
+      - name: Setup workspace
+        uses: ./.github/actions/setup
       - name: Typecheck
         run: bun run typecheck
       - name: Lint
         run: bun run lint
+
+  # ---------------------------------------------------------------------------
+  # Contracts: Foundry build/test, enforced coverage (>=90%), gated Slither.
+  # ---------------------------------------------------------------------------
+  contracts:
+    name: Contracts (Foundry)
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ github.event_name != 'schedule' && needs.detect-changes.outputs.contracts == 'true' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Setup workspace
+        uses: ./.github/actions/setup
+
+      - name: Install Foundry (pinned)
+        uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1
+        with:
+          version: ${{ env.FOUNDRY_VERSION }}
+
+      # Cache the (otherwise uncommitted) Foundry libs and build artifacts so we do not
+      # re-clone v4-core / forge-std / OZ and recompile on every run.
+      - name: Cache Foundry libs + build artifacts
+        id: foundry-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            packages/contracts/lib
+            packages/contracts/out
+            packages/contracts/cache
+          key: ${{ runner.os }}-foundry-${{ env.FOUNDRY_VERSION }}-${{ hashFiles('packages/contracts/foundry.toml', 'packages/contracts/remappings.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-foundry-${{ env.FOUNDRY_VERSION }}-
+
+      # lib/ is tracked only as orphaned gitlinks (no .gitmodules), so a fresh checkout
+      # leaves it empty. Install pinned versions, but only on a cache miss.
+      - name: Install contract libs (pinned, cache-miss only)
+        if: steps.foundry-cache.outputs.cache-hit != 'true'
+        working-directory: packages/contracts
+        run: |
+          set -euo pipefail
+          rm -rf lib
+          # Pins reproduce the exact commits recorded as gitlinks in the working tree;
+          # OpenZeppelin is pinned to the v5.5.0 release tag.
+          forge install foundry-rs/forge-std@ebc60f500bc6870baaf321a0196fddc24d6edb03 --no-git
+          forge install Uniswap/v4-core@d153b048868a60c2403a3ef5b2301bb247884d46 --no-git
+          forge install OpenZeppelin/openzeppelin-contracts@v5.5.0 --no-git
+
+      - name: Build
+        working-directory: packages/contracts
+        run: forge build --via-ir
+
+      - name: Test
+        working-directory: packages/contracts
+        run: forge test -vvv
+
+      - name: Coverage (enforce >= 90%)
+        working-directory: packages/contracts
+        run: |
+          set -euo pipefail
+          forge coverage --report summary --report lcov --ir-minimum | tee coverage-summary.txt
+          python3 - <<'PY'
+          import re, sys
+
+          total = None
+          with open("coverage-summary.txt") as fh:
+              for line in fh:
+                  if line.strip().lower().startswith(("| total", "total")):
+                      total = line
+                      break
+
+          if total is None:
+              sys.exit("Could not find a 'Total' line in the forge coverage summary")
+
+          # A summary row (forge >= 1.x) looks like:
+          #   | Total | 66.67% (2/3) | 57.14% (4/7) | 0.00% (0/1) | 66.67% (2/3) |
+          # Columns are % Lines | % Statements | % Branches | % Funcs. Take the FIRST
+          # number in each of the four cells after 'Total' (the percentage); this is
+          # robust to the trailing "(hits/found)" hit-count annotation.
+          cells = [c.strip() for c in total.strip().strip("|").split("|")]
+
+          def first_num(cell):
+              m = re.search(r"(\d+(?:\.\d+)?)", cell)
+              return float(m.group(1)) if m else None
+
+          vals = [first_num(cell) for cell in cells[1:5]]
+          if len(vals) < 4 or any(v is None for v in vals):
+              sys.exit(f"Could not parse coverage columns from: {total!r}")
+
+          lines, statements, branches, funcs = vals
+          print(
+              f"Coverage -> lines: {lines}%  statements: {statements}%  "
+              f"branches: {branches}%  funcs: {funcs}%"
+          )
+
+          # Hard-gate on the canonical coverage metrics (line/statement/function). Branch
+          # coverage is reported but NOT gated: it is noisy and "coverage > 90%" denotes
+          # line/statement coverage, not branch coverage.
+          threshold = 90.0
+          gated = [("lines", lines), ("statements", statements), ("functions", funcs)]
+          failed = [f"{name} {value}% < {threshold}%" for name, value in gated if value < threshold]
+          if failed:
+              sys.exit("Coverage below 90% threshold -> " + "; ".join(failed))
+          print(f"Coverage meets the >= 90% threshold (branches {branches}% reported, not gated)")
+          PY
+
+      - name: Install Slither + solc
+        run: |
+          set -euo pipefail
+          pip3 install --no-cache-dir slither-analyzer solc-select
+          solc-select install 0.8.31
+          solc-select use 0.8.31
+
+      - name: Slither static analysis (gate on high/medium)
+        working-directory: packages/contracts
+        run: |
+          set -euo pipefail
+          # Hard gate: fail the job on any high or medium finding in project sources.
+          # Vendored deps (lib/) and tests/scripts/build artifacts are excluded.
+          slither . --fail-high --fail-medium --exclude-dependencies \
+            --filter-paths "lib|test|script|out|cache"
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          files: packages/contracts/lcov.info
+          flags: contracts
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  # ---------------------------------------------------------------------------
+  # Backend (Cloudflare Workers + Effect). Typecheck + tests + enforced coverage.
+  # ---------------------------------------------------------------------------
+  backend:
+    name: Backend (Workers + Effect)
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ github.event_name != 'schedule' && needs.detect-changes.outputs.backend == 'true' }}
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: apps/api
+    steps:
+      - name: Setup workspace
+        uses: ./.github/actions/setup
+
+      - name: Typecheck
+        run: bun run typecheck
+
       - name: Test
         run: bun run test
-        continue-on-error: true  # apps don't have tests yet
-      - name: Coverage
+
+      - name: Coverage (collect)
         run: bun run test:coverage
-        continue-on-error: true
-      - name: Upload coverage
+
+      - name: Enforce 70% line coverage
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import sys
+
+          path = "coverage/lcov.info"
+          found = hit = 0
+          try:
+              with open(path) as fh:
+                  for line in fh:
+                      if line.startswith("LF:"):
+                          found += int(line.split(":", 1)[1].strip())
+                      elif line.startswith("LH:"):
+                          hit += int(line.split(":", 1)[1].strip())
+          except FileNotFoundError:
+              sys.exit(f"Coverage file not found: {path} (did `bun run test:coverage` run?)")
+
+          if found == 0:
+              sys.exit("No covered lines recorded (LF=0); cannot evaluate the threshold")
+
+          pct = hit / found * 100
+          print(f"Backend line coverage: {hit}/{found} = {pct:.2f}%")
+          if pct < 70.0:
+              sys.exit(f"Backend line coverage {pct:.2f}% is below the 70% threshold")
+          print("Backend coverage meets the >= 70% threshold")
+          PY
+
+      - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: apps/api/coverage/lcov.info
           flags: backend
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
+  # ---------------------------------------------------------------------------
+  # Frontend (Vite + React). Route tree -> typecheck -> test -> build -> coverage.
+  # apps/web's vitest.config already enforces 70% coverage thresholds.
+  # ---------------------------------------------------------------------------
   frontend:
     name: Frontend (Vite + React)
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "24"
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: canary
-      - name: Install deps
-        run: bun install --frozen-lockfile
-      - name: Generate route tree
+    needs: detect-changes
+    if: ${{ github.event_name != 'schedule' && needs.detect-changes.outputs.frontend == 'true' }}
+    permissions:
+      contents: read
+    defaults:
+      run:
         working-directory: apps/web
-        run: bunx @tanstack/router-cli generate
+    steps:
+      - name: Setup workspace
+        uses: ./.github/actions/setup
+
+      - name: Generate route tree
+        run: bunx tsr generate
 
       - name: Typecheck
-        working-directory: apps/web
         run: bun run typecheck
-      - name: Lint
-        working-directory: apps/web
-        run: bun run lint
+
       - name: Test
-        working-directory: apps/web
         run: bun run test
-        continue-on-error: true
+
       - name: Build
-        working-directory: apps/web
         run: bun run build
-        continue-on-error: true  # apps don't have build yet
-      - name: Coverage
-        working-directory: apps/web
+
+      - name: Coverage (enforce >= 70%, configured in vitest.config.ts)
         run: bun run test:coverage
-        continue-on-error: true
-      - name: Upload coverage
+
+      - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: apps/web/coverage/lcov.info
           flags: frontend
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
+  # ---------------------------------------------------------------------------
+  # Playwright E2E (apps/web test:e2e). Advisory for now: real failures show red on
+  # this job, but it is NOT wired into the ci-status gate until the suite stabilises.
+  # ---------------------------------------------------------------------------
+  e2e:
+    name: E2E (Playwright) — advisory
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ github.event_name != 'schedule' && needs.detect-changes.outputs.frontend == 'true' }}
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - name: Setup workspace
+        uses: ./.github/actions/setup
+
+      - name: Generate route tree
+        run: bunx tsr generate
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      # Equivalent to apps/web's `test:e2e` (playwright test); called directly so the
+      # --pass-with-no-tests flag is unambiguous. The flag guards against a temporarily
+      # empty suite — existing specs in apps/web/test/e2e run and must pass.
+      - name: Run E2E
+        run: bunx playwright test --pass-with-no-tests
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # ---------------------------------------------------------------------------
+  # Echidna fuzzing (advisory). Real tooling is installed and run, but the existing
+  # suite is Foundry-style invariant fuzzing, not Echidna property/assertion harnesses.
+  # Promoting to a hard gate needs an Echidna config + `echidna_*` properties (owned by
+  # the contracts workstream, out of scope here) — so it is continue-on-error and is
+  # NOT part of the ci-status gate.
+  # ---------------------------------------------------------------------------
+  echidna:
+    name: Echidna fuzz — advisory
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ github.event_name == 'schedule' || needs.detect-changes.outputs.contracts == 'true' }}
+    permissions:
+      contents: read
+    continue-on-error: true
+    env:
+      ECHIDNA_VERSION: v2.3.2
+    steps:
+      - name: Setup workspace
+        uses: ./.github/actions/setup
+
+      - name: Install Foundry (pinned)
+        uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1
+        with:
+          version: ${{ env.FOUNDRY_VERSION }}
+
+      - name: Cache Foundry libs + build artifacts
+        id: echidna-foundry-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            packages/contracts/lib
+            packages/contracts/out
+            packages/contracts/cache
+          key: ${{ runner.os }}-foundry-${{ env.FOUNDRY_VERSION }}-${{ hashFiles('packages/contracts/foundry.toml', 'packages/contracts/remappings.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-foundry-${{ env.FOUNDRY_VERSION }}-
+
+      - name: Install contract libs (pinned, cache-miss only)
+        if: steps.echidna-foundry-cache.outputs.cache-hit != 'true'
+        working-directory: packages/contracts
+        run: |
+          set -euo pipefail
+          rm -rf lib
+          forge install foundry-rs/forge-std@ebc60f500bc6870baaf321a0196fddc24d6edb03 --no-git
+          forge install Uniswap/v4-core@d153b048868a60c2403a3ef5b2301bb247884d46 --no-git
+          forge install OpenZeppelin/openzeppelin-contracts@v5.5.0 --no-git
+
+      - name: Build contracts
+        working-directory: packages/contracts
+        run: forge build --via-ir
+
+      - name: Install Echidna + solc
+        run: |
+          set -euo pipefail
+          # Official static linux binary (x86_64) for Ubuntu runners.
+          url="https://github.com/crytic/echidna/releases/download/${ECHIDNA_VERSION}/echidna-${ECHIDNA_VERSION#v}-x86_64-linux.tar.gz"
+          curl -fsSL "$url" -o /tmp/echidna.tar.gz
+          tar -xzf /tmp/echidna.tar.gz -C /tmp echidna
+          sudo mv /tmp/echidna /usr/local/bin/echidna
+          echo "Echidna version: $(echidna --version)"
+          pip3 install --no-cache-dir solc-select
+          solc-select install 0.8.31
+          solc-select use 0.8.31
+
+      - name: Run Echidna (assertion mode)
+        working-directory: packages/contracts
+        run: |
+          set -euo pipefail
+          # Compile + fuzz the hook's bytecode for assertion violations. Crytic-compile
+          # auto-detects foundry.toml for import/remapping resolution. A dedicated
+          # Echidna config + property harness will sharpen and eventually gate this.
+          echidna src/hook/AetherHook.sol \
+            --contract AetherHook \
+            --test-mode assertion \
+            --corpus-dir /tmp/echidna-corpus \
+            --test-limit 50000
+
+  # ---------------------------------------------------------------------------
+  # Required status gate. Required jobs must be success or skipped (path-filtered out);
+  # 'cancelled' is treated as neutral (superseded/manual stop). failure/timed_out FAIL.
+  # ---------------------------------------------------------------------------
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
-    needs: [contracts, backend, frontend]
-    if: always()
+    needs: [detect-changes, quality, contracts, backend, frontend]
+    if: ${{ github.event_name != 'schedule' && always() }}
+    permissions:
+      contents: read
     steps:
-      - name: Check all jobs passed
+      - name: Evaluate required jobs
+        env:
+          DETECT: ${{ needs.detect-changes.result }}
+          QUALITY: ${{ needs.quality.result }}
+          CONTRACTS: ${{ needs.contracts.result }}
+          BACKEND: ${{ needs.backend.result }}
+          FRONTEND: ${{ needs.frontend.result }}
         run: |
-          if [ "${{ needs.contracts.result }}" != "success" ] || \
-             [ "${{ needs.backend.result }}" != "success" ] || \
-             [ "${{ needs.frontend.result }}" != "success" ]; then
-            echo "One or more jobs failed"
+          set -euo pipefail
+          fail=0
+          check() {
+            name="$1"
+            result="$2"
+            case "$result" in
+              success | skipped | cancelled)
+                echo "[${name}] ${result} -> OK"
+                ;;
+              *)
+                echo "[${name}] ${result} -> FAIL"
+                fail=1
+                ;;
+            esac
+          }
+          check "detect-changes" "${DETECT}"
+          check "quality" "${QUALITY}"
+          check "contracts" "${CONTRACTS}"
+          check "backend" "${BACKEND}"
+          check "frontend" "${FRONTEND}"
+
+          if [ "${fail}" -ne 0 ]; then
+            echo "One or more required jobs did not pass."
             exit 1
           fi
-          echo "All jobs passed"
+          echo "All required jobs passed (success/skipped/cancelled)."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,14 @@ on:
   pull_request:
     branches: [main, develop]
   schedule:
-    - cron: "0 6 * * 1"  # Weekly Monday 6am UTC
+    - cron: "0 6 * * 1" # Weekly Monday 6am UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   analyze:
@@ -20,14 +27,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [javascript-typescript]
+        # javascript-typescript: apps + tooling. actions: scans .github/workflows +
+        # .github/actions for GitHub Actions injection / unsafe-expression issues.
+        language: [javascript-typescript, actions]
     steps:
-      - uses: actions/checkout@v7
-      - uses: github/codeql-action/init@v4
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: ${{ matrix.language }}
+          build-mode: none # interpreted languages + actions are extracted without a build
           config-file: ./.github/codeql-config.yml
-      - uses: github/codeql-action/analyze@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           category: "/language:${{ matrix.language }}"
           upload: always

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false # this job needs no authenticated git ops (artipacked)
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -35,9 +35,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Renovate authenticates via RENOVATE_TOKEN (below), not the checkout token, so
+          # don't leave the default token persisted in .git/config (artipacked hardening).
+          persist-credentials: false
 
       # Runs Renovate inside its official container using a fine-grained PAT
-      # (secrets.RENOVATE_TOKEN: contents:write + pull_requests:write on this repo).
+      # (secrets.RENOVATE_TOKEN) scoped to THIS repo with:
+      #   Contents: read and write        -> update dependency files / lockfiles
+      #   Pull requests: read and write   -> open/manage update PRs
+      #   Workflows: read and write       -> required: the github-actions manager rewrites
+      #                                       .github/workflows/*.yml; without it, action
+      #                                       SHA bumps silently fail to open PRs.
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@3064367f740a1a91cca218698a63902689cce200 # v46.1.20
         with:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,52 @@
+name: Renovate
+
+# Self-hosted Renovate. Owns ALL dependency automation that Dependabot previously
+# attempted (npm/bun + github-actions), grouped per lockfile in renovate.json so the
+# single root bun.lock is regenerated once per PR (no conflicting PR storms).
+on:
+  schedule:
+    - cron: "0 5 * * 1" # Weekly Monday 5am UTC
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: "Dry run: log what would change without opening/updating PRs"
+        required: false
+        default: false
+        type: boolean
+      logLevel:
+        description: "Renovate log level"
+        required: false
+        default: "info"
+        type: choice
+        options: [debug, info, warn, error]
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false # never interrupt an in-flight Renovate run
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    name: Renovate (self-hosted)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Runs Renovate inside its official container using a fine-grained PAT
+      # (secrets.RENOVATE_TOKEN: contents:write + pull_requests:write on this repo).
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@3064367f740a1a91cca218698a63902689cce200 # v46.1.20
+        with:
+          configurationFile: renovate.json
+          # Pin the Renovate container to a specific FULL image (includes bun, needed to
+          # regenerate the bun.lock). The action SHA above pins the wrapper.
+          renovate-version: 46.1.20-full
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_DRY_RUN: ${{ inputs.dryRun && 'full' || '' }}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ bun run test
 bun run test:coverage
 ```
 
+## Dependency Automation (Renovate)
+
+Renovate (`.github/workflows/renovate.yml` + `renovate.json`) owns dependency updates for
+`bun` and `github-actions`; Dependabot is kept only as a security-update fallback.
+
+The workflow authenticates with a **fine-grained PAT** stored as `RENOVATE_TOKEN`, scoped to
+this repository with:
+
+- **Contents: read and write** — update dependency files and lockfiles
+- **Pull requests: read and write** — open and manage update PRs
+- **Workflows: read and write** — required because the `github-actions` manager rewrites
+  `.github/workflows/*.yml`; without it, action SHA bumps silently fail to open PRs
+
 ## Scope
 
 Lean spot DEX: Swap + Concentrated Liquidity + Token Search + Real-time Charts + Wallet Connect + Slippage/MEV protection.

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     ":semanticCommits",
     "schedule:weekly"
   ],
-  "enabledManagers": ["npm", "github-actions"],
+  "enabledManagers": ["bun", "npm", "github-actions"],
   "labels": ["dependencies"],
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "Renovate Dependency Dashboard",
@@ -39,8 +39,8 @@
   },
   "packageRules": [
     {
-      "description": "ALL npm/bun workspace updates -> one PR so the single root bun.lock is regenerated once (no per-directory PR storms).",
-      "matchManagers": ["npm"],
+      "description": "ALL bun workspace updates -> one PR so the single root bun.lock is regenerated once (no per-directory PR storms).",
+      "matchManagers": ["bun"],
       "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest", "replacement", "rollback"],
       "matchFileNames": ["bun.lock", "package.json", "apps/**/package.json", "packages/**/package.json"],
       "groupName": "bun dependencies",
@@ -55,7 +55,7 @@
     },
     {
       "description": "Bun runtime is intentionally 'canary' (packageManager field) - Renovate must not bump it.",
-      "matchManagers": ["npm"],
+      "matchManagers": ["bun"],
       "matchPackageNames": ["bun"],
       "enabled": false
     }

--- a/renovate.json
+++ b/renovate.json
@@ -39,8 +39,8 @@
   },
   "packageRules": [
     {
-      "description": "ALL bun workspace updates -> one PR so the single root bun.lock is regenerated once (no per-directory PR storms).",
-      "matchManagers": ["bun"],
+      "description": "ALL bun workspace updates -> one PR so the single root bun.lock is regenerated once (no per-directory PR storms). npm extracts the package.json manifests; bun handles bun.lock - both feed this group.",
+      "matchManagers": ["bun", "npm"],
       "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest", "replacement", "rollback"],
       "matchFileNames": ["bun.lock", "package.json", "apps/**/package.json", "packages/**/package.json"],
       "groupName": "bun dependencies",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    "schedule:weekly"
+  ],
+  "enabledManagers": ["npm", "github-actions"],
+  "labels": ["dependencies"],
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Renovate Dependency Dashboard",
+  "prHourlyLimit": 4,
+  "prConcurrentLimit": 10,
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
+  "commitMessageAction": "update",
+  "platformCommit": "enabled",
+  "rangeStrategy": "bump",
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/.archive-contracts-2026/**",
+    "**/.cache/**",
+    "**/.wrangler/**",
+    "packages/contracts/lib/**",
+    "packages/contracts/out/**",
+    "packages/contracts/cache/**"
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"],
+    "commitMessagePrefix": "fix(security):"
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"],
+    "commitMessageAction": "maintain",
+    "description": "Weekly regenerate of the single root bun.lock to pick up transitive updates in one PR."
+  },
+  "packageRules": [
+    {
+      "description": "ALL npm/bun workspace updates -> one PR so the single root bun.lock is regenerated once (no per-directory PR storms).",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest", "replacement", "rollback"],
+      "matchFileNames": ["bun.lock", "package.json", "apps/**/package.json", "packages/**/package.json"],
+      "groupName": "bun dependencies",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "description": "All GitHub Actions version bumps (incl. SHA-pinned) -> one PR.",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest", "replacement"],
+      "groupName": "github actions",
+      "semanticCommitScope": "ci"
+    },
+    {
+      "description": "Bun runtime is intentionally 'canary' (packageManager field) - Renovate must not bump it.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["bun"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
## Workstream C — CI/CD modernization

Rewrites `.github/workflows/ci.yml`, improves `codeql.yml`, replaces Dependabot's npm automation with self-hosted Renovate, and adds supply-chain hardening + QA wiring.

> ⚠️ **Merge ordering (read first).** This PR must merge **AFTER** the concurrent toolchain/Effect migration PR (`feat/effect-v4-toolchain`, Workstream P). This PR removes the `continue-on-error` masks so failures fail the build. Full green depends on that migration making typecheck/lint/test/coverage green. (CI here calls the workspace **scripts** — `bun run typecheck|lint|test|build|test:coverage` — not `tsgo`/`tsc` directly, so it is correct both before and after P swaps `tsgo` for `tsc` and updates Effect/unittest deps.)

---

## What's included

### C1 — Correctness gate
- **Removed the blanket `continue-on-error: true`** that masked failures (was on Test/Build/Coverage), so a real typecheck/lint/test/build failure now **fails the job**.
- **Coverage thresholds enforced** (from AGENTS.md): backend ≥ 70% lines, frontend ≥ 70% lines, contracts ≥ 90% (lines/statements/functions gated; branch % reported, not gated — branch coverage is noisy and "90%" denotes line coverage).
- **`ci-status` fixed**: treats `success`/`skipped` (path-filtered-out)/`cancelled` (superseded) as OK, and fails only on `failure`/`timed_out`. Skipped jobs no longer break the gate.

### C2 — Contracts job
- **Pinned Foundry toolchain** `v1.7.1` via `foundry-rs/foundry-toolchain` (SHA-pinned).
- **Pinned contract lib versions** to the exact commits recorded as the (orphaned, `.gitmodules`-less) gitlinks: forge-std `ebc60f50`, Uniswap/v4-core `d153b048`, OpenZeppelin `@v5.5.0`. No more floating `forge install <latest>` on every run.
- **Cached** `packages/contracts/lib`, `out`, `cache` keyed on `foundry.toml` + `remappings.txt` (+ Foundry version); libs reinstall only on cache miss.
- **Slither actually runs and is gated**: `pip install slither-analyzer solc-select` + solc 0.8.31, then `slither --fail-high --fail-medium --exclude-dependencies` (no `|| true`, no `if command -v`).

### C3 — Speed
- **Bun install cache** (`~/.bun/install/cache`) keyed on `bun.lock` hash.
- **Path filters** via `dorny/paths-filter` in a prep job: contracts runs only on `packages/contracts/**` (+ root), backend on `apps/api/**` (+ root), frontend on `apps/web/**` (+ root); a fast **Typecheck+Lint** quality job runs on any code change (root `tsconfig` excludes `apps/**`, so per-workspace typechecks cover the apps).
- **DRY setup** in a composite action `.github/actions/setup/action.yml` (Node 24 + Bun canary + bun cache + `bun install --frozen-lockfile`). Each job runs `actions/checkout` **first** — a local composite action can't bootstrap its own checkout, so checking out inside the action fails every job.
- Typecheck+lint kept as fast early steps.

### C4 — Hardening + QA
- **ALL third-party actions pinned to full commit SHAs** (with a `# vN` tag comment each).
- **Least-privilege `permissions: contents: read`** on every job (deny-by-default at workflow level; CodeQL adds `security-events: write` only where needed).
- **Echidna fuzz job** (scheduled weekly + on contract changes) — **made honest**. We stopped pointing Echidna at `AetherHook` directly: its 4-arg constructor (rejects the default zero treasury) + hook-bit validation make a default deploy fail before any case runs, and the old `continue-on-error: true` was masking that missing coverage. It now fuzzes a real property harness under `packages/contracts/test/echidna/` **when one exists**, and otherwise **skips transparently** (`SKIPPED: no echidna harness yet`) with **no `continue-on-error`**. Adding a harness (contracts workstream) auto-enables the job. Still **not** wired into the `ci-status` gate.
- **Playwright E2E wiring** (runs the `apps/web` e2e specs). Real but **advisory for now** (not in the `ci-status` gate) until the suite stabilises; `--pass-with-no-tests` guards a temporarily-empty suite. Promote to required once green.

### C5 — Dependency automation (Renovate)
- New `renovate.json` (root) + new `.github/workflows/renovate.yml` (self-hosted Renovate, `renovatebot/github-action` SHA-pinned, weekly cron + `workflow_dispatch`, `secrets.RENOVATE_TOKEN`). **Renovate now owns npm/bun + github-actions.**
- **Dependabot reduced to a security-only fallback**: per-directory npm updates (root + `/apps/web` + `/apps/api`) removed; the survivors use `open-pull-requests-limit: 0` (no routine version-PR storms; Dependabot security updates still flow).

### C6 — Process
- Branch-protection + `RENOVATE_TOKEN` owner actions documented below. Cloudflare preview deploys need a `CLOUDFLARE_API_TOKEN` secret (see Notes) — referenced, not hardcoded.

---

## Files changed
- `.github/workflows/ci.yml` (rewrite)
- `.github/workflows/codeql.yml` (SHA pins, `actions` language, `build-mode: none`)
- `.github/codeql-config.yml` (scan `.github/**`)
- `.github/workflows/renovate.yml` (new)
- `.github/actions/setup/action.yml` (new composite)
- `renovate.json` (new)
- `.github/dependabot.yml` (trimmed to security-only fallback)

## Renovate group config (single root `bun.lock`)
- `enabledManagers: [bun, npm, github-actions]` (the `bun` manager owns this repo's single root `bun.lock`)
- **One group for all bun updates** (`groupName: "bun dependencies"`, all update types incl. major) so the shared `bun.lock` is regenerated **once per PR**; a second group for `github-actions` (updates the SHA pins while keeping `# vN` comments).
- `lockFileMaintenance: enabled` (weekly), `rangeStrategy: "bump"` (for `^` ranges), `semanticCommits` (`chore(deps):` prefix), `labels: ["dependencies"]`, `prConcurrentLimit: 10`, `prHourlyLimit: 4`, `vulnerabilityAlerts` enabled (`security` label). The `bun` runtime (`canary`) is excluded from updates.

## Hardening — action SHAs pinned
| Action | Pin | SHA |
|---|---|---|
| actions/checkout | v7 | `3d3c42e5aac5ba805825da76410c181273ba90b1` |
| actions/setup-node | v7 | `820762786026740c76f36085b0efc47a31fe5020` |
| oven-sh/setup-bun | v2 | `0c5077e51419868618aeaa5fe8019c62421857d6` |
| actions/cache | v6 | `55cc8345863c7cc4c66a329aec7e433d2d1c52a9` |
| actions/upload-artifact | v4 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| codecov/codecov-action | v7 | `fb8b3582c8e4def4969c97caa2f19720cb33a72f` |
| github/codeql-action | v4 | `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` |
| foundry-rs/foundry-toolchain | v1 | `b00af27efadbc7b4ca8b82abbd903b17cc874d2a` |
| dorny/paths-filter | v4 | `7b450fff21473bca461d4b92ce414b9d0420d706` |
| renovatebot/github-action | v46.1.20 | `3064367f740a1a91cca218698a63902689cce200` |

Renovate keeps these SHAs current via the `github-actions` group while we stay supply-chain safe.

---

## Owner actions required

### 1) `RENOVATE_TOKEN` (for self-hosted Renovate)
Create a **fine-grained PAT** scoped to this repo with **all** of:
- **`Contents: Read and write`** — update dependency files / lockfiles
- **`Pull requests: Read and write`** — open and manage update PRs
- **`Workflows: Read and write`** — **required**: the `github-actions` manager rewrites `.github/workflows/*.yml`, so without it action SHA bumps silently fail to open PRs

then:
```bash
gh secret set RENOVATE_TOKEN --repo irfndi/AetherDEX
```

### 2) Require the `ci-status` check on `main` (run AFTER this PR merges and CI is green)
```bash
gh api repos/irfndi/AetherDEX/branches/main/protection \
  -X PUT \
  -H "Accept: application/vnd.github+json" \
  --input - <<'EOF'
{
  "required_status_checks": {
    "strict": true,
    "contexts": ["ci-status"],
    "checks": [{ "context": "ci-status" }]
  },
  "enforce_admins": true,
  "required_pull_request_reviews": null,
  "restrictions": null
}
EOF
```
> I did **not** apply branch protection from this branch: the new strict `ci-status` should only be required once the migration makes it green (otherwise `main` becomes unmergeable during the transition). Set `enforce_admins: false` temporarily if you need an admin escape hatch.

---

## Notes
- **Cloudflare preview deploys:** wiring a Pages preview (`wrangler pages deploy`) / Worker versions upload needs a repo secret `CLOUDFLARE_API_TOKEN` (`wrangler` is already a devDep). Not added here to keep secrets out of scope; add the secret + a job that runs `wrangler pages deploy dist --project-name aether-dex --branch <pr>` (web) and `wrangler versions upload` (api) when ready.
- **Codecov** uploads are tokenless by default (public repo); optionally set `CODECOV_TOKEN` for reliability. `fail_ci_if_error: false` keeps uploads non-blocking.
- **Validated:** all workflow YAML parsed with `yaml.safe_load`, all actions confirmed SHA-pinned, `renovate.json` parses as JSON, and the contracts coverage parser + Slither/`--report summary --report lcov` mechanics were verified against real `forge` v1.7.1 output. All workflow YAML **and** `actionlint` (v1.7.12) pass clean; `renovate.json` + `package.json` validated as JSON; `hashFiles(...)` uses single-quoted literals throughout.
- The advisory `e2e` and `echidna` jobs are intentionally **not** in the `ci-status` gate; promote them to required checks (add to the branch-protection `checks`) once their suites are stable/green.

## Summary by Sourcery

Modernize and harden CI/CD workflows with strict status gating, path-based job selection, supply-chain safeguards, and self-hosted Renovate-based dependency automation.

New Features:
- Introduce path-based change detection to selectively run quality, backend, frontend, contracts, E2E, and Echidna jobs based on touched workspaces.
- Add advisory Playwright E2E and Echidna fuzzing jobs wired into CI but not yet enforced by the main status gate.
- Set up a shared composite action to standardize workspace checkout, Node 24 + Bun setup, bun caching, and dependency installation.
- Configure self-hosted Renovate with a dedicated workflow and repository-wide configuration to manage npm/bun and GitHub Actions updates.

Bug Fixes:
- Fix the CI status gate so only failed or timed-out required jobs block merges, while successful, skipped, or cancelled jobs pass.
- Ensure Slither static analysis and contract coverage actually run and fail the contracts job on high/medium findings or insufficient coverage.

Enhancements:
- Remove blanket continue-on-error masks so typecheck, test, build, and coverage failures now correctly fail their respective jobs.
- Enforce explicit coverage thresholds for contracts (≥90%) and backend/frontend (≥70%) via scripted checks over generated lcov reports.
- Pin Foundry toolchain, contract libraries, and all third-party GitHub Actions to specific versions/SHAs for reproducible and secure builds.
- Add caching for Foundry libraries/build artifacts and Bun installs to speed up repeated CI runs.
- Expand CodeQL analysis to cover both application/tooling code and GitHub workflows/actions with a safer, no-build configuration.
- Document and implement least-privilege job permissions with deny-by-default contents: read across workflows.

Build:
- Add a dedicated Renovate GitHub Actions workflow with concurrency control, configurable logging, and dry-run support.
- Introduce a composite setup action under .github/actions to DRY shared CI environment setup and bun caching logic.

CI:
- Rewrite the main CI workflow to use path filters, strict status evaluation, explicit coverage gates, and advisory E2E/fuzzing jobs.
- Update the CodeQL workflow with concurrency, pinned action SHAs, expanded language matrix, and explicit config-driven analysis.

Documentation:
- Clarify CI behavior, permissions, path filters, coverage semantics, and dependency automation strategy through inline workflow comments.

Tests:
- Wire Playwright E2E tests for the frontend into CI with artifact upload on failure.
- Integrate Echidna fuzzing for contracts as a scheduled and advisory CI job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD**
  * Expanded automated checks for code quality, contracts, backend, and frontend changes.
  * Added stricter coverage and security analysis requirements.
  * Added advisory end-to-end testing and smart-contract fuzz testing.
  * Improved workflow efficiency by skipping unaffected areas and caching setup dependencies.

* **Security**
  * Extended CodeQL scanning to include workflow and action configuration.
  * Added automated analysis for JavaScript/TypeScript and CI actions.

* **Dependency Management**
  * Added scheduled Renovate automation for dependency and security updates.
  * Consolidated dependency updates and lockfile maintenance into managed pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
