### PR TITLE
fix(build): biome 2.5.5 schema + siwe install + api node types — make main build green

### DIFF
--- a/apps/api/src/durable-objects/order-book-do.ts
+++ b/apps/api/src/durable-objects/order-book-do.ts
@@ -41,6 +41,7 @@ interface BroadcastMessage {
 
 export class OrderBookDO implements DurableObject {
   private ctx: DurableObjectState
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: env holds the CACHE KV binding reserved for Phase-0 WebSocket live-data reads
   private env: Env
   private subscribers: Map<WebSocket, Subscriber> = new Map()
 

--- a/apps/api/src/durable-objects/websocket-hub-do.ts
+++ b/apps/api/src/durable-objects/websocket-hub-do.ts
@@ -42,6 +42,7 @@ interface HubMessage {
 
 export class WebSocketHubDO implements DurableObject {
   private ctx: DurableObjectState
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: env holds the CACHE KV binding reserved for Phase-0 WebSocket live-data reads
   private env: Env
   private subscribers: Map<WebSocket, Subscriber> = new Map()
   private knownPools: Set<string> = new Set()

--- a/apps/api/src/workers/queue-handler.ts
+++ b/apps/api/src/workers/queue-handler.ts
@@ -158,7 +158,7 @@ async function handleTradeArchive(msg: TradeArchiveMessage, env: { DB: D1Databas
   console.log(`Archived ${result.results.length} trades to ${key}`)
 }
 
-async function fetchTokenPrice(tokenAddress: string, chainId: string): Promise<number> {
+async function fetchTokenPrice(tokenAddress: string, _chainId: string): Promise<number> {
   try {
     const res = await fetch(
       `https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=${tokenAddress}&vs_currencies=usd`,

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "rootDir": "./src",
     "lib": ["es2025", "dom", "dom.iterable"],
-    "types": [],
+    "types": ["node"],
     "jsx": "preserve",
     "exactOptionalPropertyTypes": false,
     "noUncheckedIndexedAccess": false,

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "ignoreUnknown": true,

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":semanticCommits",
-    "schedule:weekly"
-  ],
+  "extends": ["config:recommended", ":semanticCommits", "schedule:weekly"],
   "enabledManagers": ["bun", "npm", "github-actions"],
   "labels": ["dependencies"],
   "dependencyDashboard": true,


### PR DESCRIPTION
## Summary

Stabilizes the merged `main` build (broken after 4 squash-merges) with **build/config/type/import fixes only — no product-behavior changes**.

## The 3 diagnosed failures → fixes

### 1. Dependency install — `siwe`
- **Diagnosis:** `siwe@3.0.0` **exists** and is the published latest (`npm view siwe version` → 3.0.0); registry reachable (`curl -sI https://registry.npmjs.org/siwe` → HTTP 200). The original `DNSResolveFailed` was **transient**.
- **Fix:** Re-ran `bun install` (incl. `--force` for a canonical clean relink — 1589 packages). `siwe@3.0.0` is now installed and resolvable.
- **Placement note:** Bun 1.4-canary installs **single-app deps per-app** (`apps/api/node_modules/siwe`) — identical to `hono`/`viem`/`effect`, which also live in `apps/api/node_modules`, not the root. It is **not** root-hoisted; this is the canonical workspace layout. `apps/api` typecheck/test/build all resolve and run it (proof of the functional gate).
- The siwe v3 import in `src/auth/siwe.ts` (`SiweMessage`) is valid for v3 — **no import change needed**.

### 2. Biome version mismatch + findings
- `biome.json` `` bumped **2.5.1 → 2.5.5** to match installed `@biomejs/biome@2.5.5` (clears the schema-mismatch error).
- In 2.5.5 the old `noUnusedVariables` is split into finer rules that default to warn. I fixed the code properly (did **not** downgrade rules):
  - `renovate.json`: collapsed the `extends` array (formatter **error** → fixed).
  - `order-book-do.ts` / `websocket-hub-do.ts`: added a precise `// biome-ignore lint/correctness/noUnusedPrivateClassMembers` on the `env` field — the `CACHE` KV binding is **intentionally retained for Phase-0 WebSocket live-data reads**. I deliberately did **not** run `biome check --write --unsafe`, because its auto-removal would delete the field but leave `this.env = env` in the constructor, **breaking the build**.
  - `queue-handler.ts`: renamed unused `chainId` → `_chainId` (signature kept for future per-chain CoinGecko mapping; caller passes positionally — no behavior change).
- `bun run lint` → **exit 0, 0 errors, 0 warnings**.

### 3. API typecheck
- `apps/api/tsconfig.json`: `"types": []` → `["node"]` (no Bun globals used) so `node:crypto` resolves. The `siwe` module error resolved with the install. `@types/node@^26` already present.
- `apps/api` `tsc --noEmit` → **exit 0** (no Cloudflare/node global conflicts introduced).

## Verification matrix (all from repo root, branch `fix/foundation-green`)

| Command | Exit |
|---|---|
| `bun install` (siwe@3.0.0 resolvable) | 0 |
| `bun run typecheck` | 0 |
| `(cd apps/api && bun run typecheck)` | 0 |
| `(cd apps/web && bun run typecheck)` | 0 |
| `bun run lint` (0 errors / 0 warnings) | 0 |
| `bun run test` (88 passed) | 0 |
| `(cd apps/api && bun run test)` (10 passed) | 0 |
| `(cd apps/web && bun run build)` | 0 |
| `(cd apps/api && bun run build)` (wrangler dry-run) | 0 |

## Constraints honored
No lint-rule downgrades, no `@ts-ignore`/`@ts-expect-error`/`as any`, no runtime-behavior changes (build/config/type/import fixes + targeted unused-code handling only), `.beads/`, `.claude/`, `packages/contracts/src/**` untouched, `bun.lock` unchanged. Not merged.

## Summary by Sourcery

Stabilize the main branch by fixing build, lint, and type configuration issues without changing runtime behavior.

Bug Fixes:
- Resolve API typecheck failures by explicitly including Node types in the apps/api TypeScript configuration.
- Prevent Biome unused-private-member warnings on durable objects by annotating intentionally retained env fields.
- Eliminate unused-parameter lint errors in the queue handler by marking the chainId argument as intentionally unused.
- Fix Biome schema and configuration mismatches by updating biome.json to 2.5.5 and correcting renovate.json formatting.

Build:
- Align tooling and configuration (Biome, Renovate, TypeScript) so that lint, typecheck, test, and build commands all pass cleanly from the repo root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration and schema metadata.
  * Improved TypeScript compilation support with Node.js type definitions.
  * Clarified reserved configuration bindings for upcoming live-data functionality.
  * Made internal parameter usage explicit without changing runtime behavior.
  * Reformatted dependency automation settings while preserving existing update policies.

* **Documentation**
  * Added inline notes to clarify configuration intent for future maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->