### PR TITLE
fix: Phase-0 review follow-up for merged PRs #306 + #307

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -39,6 +39,20 @@ bun run deploy:staging
 bun run deploy:production
 ```
 
+## Dependency notes (explicit exceptions)
+
+The repo policy is "latest, always"; these pins are deliberate exceptions:
+
+- **`jsbi@^3.2.5`** — must match `@uniswap/v3-sdk`'s JSBI major version. The quote-engine
+  tests compose the canonical `SwapMath.computeSwapStep` primitive, which consumes and
+  returns JSBI values; mixing JSBI v4 (incompatible class identity) with the SDK's v3
+  values breaks the math interop.
+- **`ethers@^5` + `@ethersproject/*`** (dev) — required ONLY by the Workers test pool.
+  `siwe` and the Uniswap SDK barrels hard-import ethers v5 paths that workerd cannot
+  link; `test/shims/ethers-worker-shim.ts` (aliased in `vitest.config.ts`) viem-backs
+  those bare specifiers for tests, while production bundles the real packages via
+  esbuild. Not a runtime dependency of the Worker.
+
 ## Architecture
 
 See `AGENTS.md` for full architecture overview.

--- a/apps/api/migrations/0003_chain_scoped_tokens.sql
+++ b/apps/api/migrations/0003_chain_scoped_tokens.sql
@@ -1,0 +1,65 @@
+-- Chain-scope the token cache (Phase-0 review of PR #307).
+--
+-- Tokens are keyed by (chain_id, address): the SAME address on two chains is two
+-- different tokens, so address alone must not be the key (cross-chain upserts from
+-- the validated token list would otherwise overwrite each other's cache rows, and
+-- reads could leak another chain's tokens). SQLite cannot re-key a PRIMARY KEY via
+-- ALTER, so the table is rebuilt and data is carried over with chain_id = 1 (the
+-- only chain indexed today).
+CREATE TABLE IF NOT EXISTS tokens_chain_scoped (
+    chain_id INTEGER NOT NULL,
+    address TEXT NOT NULL,
+    symbol TEXT NOT NULL,
+    name TEXT NOT NULL,
+    decimals INTEGER NOT NULL,
+    logo_url TEXT,
+    is_verified INTEGER NOT NULL DEFAULT 0,   -- 0/1 boolean
+    is_native INTEGER NOT NULL DEFAULT 0,     -- 1 if this is native ETH/wrap
+    total_supply TEXT,                        -- big number as string
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (chain_id, address)
+);
+INSERT OR IGNORE INTO tokens_chain_scoped
+    (chain_id, address, symbol, name, decimals, logo_url, is_verified, is_native, total_supply, created_at, updated_at)
+  SELECT 1, address, symbol, name, decimals, logo_url, is_verified, is_native, total_supply, created_at, updated_at
+  FROM tokens;
+DROP TABLE tokens;
+ALTER TABLE tokens_chain_scoped RENAME TO tokens;
+CREATE INDEX IF NOT EXISTS idx_tokens_symbol ON tokens(symbol);
+CREATE INDEX IF NOT EXISTS idx_tokens_verified ON tokens(chain_id, is_verified, symbol);
+
+-- The pools table carried address-only FOREIGN KEYs into tokens(address); with the
+-- composite (chain_id, address) primary key above they are no longer satisfiable.
+-- Pool tokens are not guaranteed to appear in the default token list at all, so the
+-- FKs are dropped when pools is rebuilt (pool_id stays the primary key, keeping the
+-- transactions / liquidity_positions FOREIGN KEYs into pools(pool_id) valid).
+-- NOTE: pools itself becomes chain-qualified when the Phase-3 indexer ingests a
+-- second chain (AGENTS.md "chain-qualified keys before a second chain is indexed").
+CREATE TABLE IF NOT EXISTS pools_v2 (
+    pool_id TEXT PRIMARY KEY NOT NULL,        -- bytes32 as hex string
+    token0_address TEXT NOT NULL,
+    token1_address TEXT NOT NULL,
+    fee INTEGER NOT NULL,                     -- fee tier (e.g. 3000 = 0.3%)
+    tick_spacing INTEGER NOT NULL,
+    hook_address TEXT,                        -- AetherHook address
+    sqrt_price_x96 TEXT NOT NULL,             -- current sqrt price (big number as string)
+    current_tick INTEGER NOT NULL,
+    liquidity TEXT NOT NULL,                  -- total liquidity (big number as string)
+    tvl_usd REAL NOT NULL DEFAULT 0,
+    volume_24h_usd REAL NOT NULL DEFAULT 0,
+    fees_24h_usd REAL NOT NULL DEFAULT 0,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+INSERT OR IGNORE INTO pools_v2
+    (pool_id, token0_address, token1_address, fee, tick_spacing, hook_address, sqrt_price_x96, current_tick,
+     liquidity, tvl_usd, volume_24h_usd, fees_24h_usd, is_active, created_at, updated_at)
+  SELECT pool_id, token0_address, token1_address, fee, tick_spacing, hook_address, sqrt_price_x96, current_tick,
+         liquidity, tvl_usd, volume_24h_usd, fees_24h_usd, is_active, created_at, updated_at
+  FROM pools;
+DROP TABLE pools;
+ALTER TABLE pools_v2 RENAME TO pools;
+CREATE INDEX IF NOT EXISTS idx_pools_active ON pools(is_active, tvl_usd DESC);
+CREATE INDEX IF NOT EXISTS idx_pools_tokens ON pools(token0_address, token1_address);

--- a/apps/api/migrations/0003_chain_scoped_tokens.sql
+++ b/apps/api/migrations/0003_chain_scoped_tokens.sql
@@ -1,11 +1,118 @@
 -- Chain-scope the token cache (Phase-0 review of PR #307).
 --
--- Tokens are keyed by (chain_id, address): the SAME address on two chains is two
--- different tokens, so address alone must not be the key (cross-chain upserts from
--- the validated token list would otherwise overwrite each other's cache rows, and
--- reads could leak another chain's tokens). SQLite cannot re-key a PRIMARY KEY via
--- ALTER, so the table is rebuilt and data is carried over with chain_id = 1 (the
+-- Tokens become keyed by (chain_id, address): the SAME address on two chains is
+-- two different token, so address alone must not be the key (cross-chain upserts
+-- from the validated token list would otherwise overwrite each other's cache rows,
+-- and reads could leak another chain's tokens). SQLite cannot re-key a PRIMARY KEY
+-- via ALTER, so tables are rebuilt and data carried over with chain_id = 1 (the
 -- only chain indexed today).
+--
+-- FK enforcement may reject `DROP TABLE` while another table still references the
+-- dropped one, so the tables with cross-references are ALL rebuilt in children-first
+-- order (transactions / liquidity_positions → pools → tokens), dropping the
+-- address-only / pool-only FOREIGN KEYs that the new composite keys no longer
+-- satisfy. The guard PRAGMA below additionally disables enforcement for runners
+-- that execute migrations outside a transaction (it is a no-op inside one).
+PRAGMA foreign_keys = off;
+
+-- transactions: keep users FK (users is unaffected); drop the pools FK (pools is
+-- rebuilt below with the same pool_id primary key, so the reference stays valid,
+-- but the drop must not be blocked during the rebuild).
+CREATE TABLE IF NOT EXISTS transactions_chain_aware (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tx_hash TEXT UNIQUE NOT NULL,
+    user_address TEXT NOT NULL,
+    pool_id TEXT,                                     -- nullable for non-pool txs
+    tx_type TEXT NOT NULL,                            -- 'swap' | 'add_liquidity' | 'remove_liquidity' | 'create_pool'
+    token_in TEXT,
+    token_out TEXT,
+    amount_in TEXT,                                   -- big number as string
+    amount_out TEXT,                                  -- big number as string
+    amount_usd REAL,
+    gas_used INTEGER,
+    gas_price TEXT,
+    block_number INTEGER NOT NULL,
+    block_timestamp INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',           -- 'pending' | 'confirmed' | 'failed'
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (user_address) REFERENCES users(address)
+);
+INSERT OR IGNORE INTO transactions_chain_aware
+    (id, tx_hash, user_address, pool_id, tx_type, token_in, token_out, amount_in, amount_out, amount_usd,
+     gas_used, gas_price, block_number, block_timestamp, status, created_at)
+  SELECT id, tx_hash, user_address, pool_id, tx_type, token_in, token_out, amount_in, amount_out, amount_usd,
+         gas_used, gas_price, block_number, block_timestamp, status, created_at
+  FROM transactions;
+DROP TABLE transactions;
+ALTER TABLE transactions_chain_aware RENAME TO transactions;
+CREATE INDEX IF NOT EXISTS idx_tx_user ON transactions(user_address, block_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_tx_pool ON transactions(pool_id, block_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_tx_block ON transactions(block_number DESC);
+CREATE INDEX IF NOT EXISTS idx_tx_status ON transactions(status);
+
+-- liquidity_positions: keep users FK; drop the pools FK for the same reason.
+CREATE TABLE IF NOT EXISTS liquidity_positions_chain_aware (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_address TEXT NOT NULL,
+    pool_id TEXT NOT NULL,
+    tick_lower INTEGER NOT NULL,
+    tick_upper INTEGER NOT NULL,
+    liquidity TEXT NOT NULL,                          -- LP tokens amount (big number as string)
+    amount0 TEXT NOT NULL,                            -- token0 amount
+    amount1 TEXT NOT NULL,                            -- token1 amount
+    fees_earned_token0 TEXT NOT NULL DEFAULT '0',
+    fees_earned_token1 TEXT NOT NULL DEFAULT '0',
+    is_active INTEGER NOT NULL DEFAULT 1,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    FOREIGN KEY (user_address) REFERENCES users(address)
+);
+INSERT OR IGNORE INTO liquidity_positions_chain_aware
+    (id, user_address, pool_id, tick_lower, tick_upper, liquidity, amount0, amount1,
+     fees_earned_token0, fees_earned_token1, is_active, created_at, updated_at)
+  SELECT id, user_address, pool_id, tick_lower, tick_upper, liquidity, amount0, amount1,
+         fees_earned_token0, fees_earned_token1, is_active, created_at, updated_at
+  FROM liquidity_positions;
+DROP TABLE liquidity_positions;
+ALTER TABLE liquidity_positions_chain_aware RENAME TO liquidity_positions;
+CREATE INDEX IF NOT EXISTS idx_lp_user ON liquidity_positions(user_address, is_active);
+CREATE INDEX IF NOT EXISTS idx_lp_pool ON liquidity_positions(pool_id, is_active);
+
+-- pools: drop the address-only FOREIGN KEYs into tokens(address) — with the composite
+-- (chain_id, address) primary key below they are no longer satisfiable, and pool
+-- tokens are not guaranteed to appear in the default token list at all. pool_id stays
+-- the primary key, keeping the transactions / liquidity_positions references valid.
+-- NOTE: pools itself becomes chain-qualified when the Phase-3 indexer ingests a
+-- second chain (AGENTS.md "chain-qualified keys before a second chain is indexed").
+CREATE TABLE IF NOT EXISTS pools_chain_aware (
+    pool_id TEXT PRIMARY KEY NOT NULL,                -- bytes32 as hex string
+    token0_address TEXT NOT NULL,
+    token1_address TEXT NOT NULL,
+    fee INTEGER NOT NULL,                             -- fee tier (e.g. 3000 = 0.3%)
+    tick_spacing INTEGER NOT NULL,
+    hook_address TEXT,                                -- AetherHook address
+    sqrt_price_x96 TEXT NOT NULL,                     -- current sqrt price (big number as string)
+    current_tick INTEGER NOT NULL,
+    liquidity TEXT NOT NULL,                          -- total liquidity (big number as string)
+    tvl_usd REAL NOT NULL DEFAULT 0,
+    volume_24h_usd REAL NOT NULL DEFAULT 0,
+    fees_24h_usd REAL NOT NULL DEFAULT 0,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+INSERT OR IGNORE INTO pools_chain_aware
+    (pool_id, token0_address, token1_address, fee, tick_spacing, hook_address, sqrt_price_x96, current_tick,
+     liquidity, tvl_usd, volume_24h_usd, fees_24h_usd, is_active, created_at, updated_at)
+  SELECT pool_id, token0_address, token1_address, fee, tick_spacing, hook_address, sqrt_price_x96, current_tick,
+         liquidity, tvl_usd, volume_24h_usd, fees_24h_usd, is_active, created_at, updated_at
+  FROM pools;
+DROP TABLE pools;
+ALTER TABLE pools_chain_aware RENAME TO pools;
+CREATE INDEX IF NOT EXISTS idx_pools_active ON pools(is_active, tvl_usd DESC);
+CREATE INDEX IF NOT EXISTS idx_pools_tokens ON pools(token0_address, token1_address);
+
+-- tokens: composite (chain_id, address) primary key.
 CREATE TABLE IF NOT EXISTS tokens_chain_scoped (
     chain_id INTEGER NOT NULL,
     address TEXT NOT NULL,
@@ -13,9 +120,9 @@ CREATE TABLE IF NOT EXISTS tokens_chain_scoped (
     name TEXT NOT NULL,
     decimals INTEGER NOT NULL,
     logo_url TEXT,
-    is_verified INTEGER NOT NULL DEFAULT 0,   -- 0/1 boolean
-    is_native INTEGER NOT NULL DEFAULT 0,     -- 1 if this is native ETH/wrap
-    total_supply TEXT,                        -- big number as string
+    is_verified INTEGER NOT NULL DEFAULT 0,           -- 0/1 boolean
+    is_native INTEGER NOT NULL DEFAULT 0,             -- 1 if this is native ETH/wrap
+    total_supply TEXT,                                -- big number as string
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL,
     PRIMARY KEY (chain_id, address)
@@ -29,37 +136,6 @@ ALTER TABLE tokens_chain_scoped RENAME TO tokens;
 CREATE INDEX IF NOT EXISTS idx_tokens_symbol ON tokens(symbol);
 CREATE INDEX IF NOT EXISTS idx_tokens_verified ON tokens(chain_id, is_verified, symbol);
 
--- The pools table carried address-only FOREIGN KEYs into tokens(address); with the
--- composite (chain_id, address) primary key above they are no longer satisfiable.
--- Pool tokens are not guaranteed to appear in the default token list at all, so the
--- FKs are dropped when pools is rebuilt (pool_id stays the primary key, keeping the
--- transactions / liquidity_positions FOREIGN KEYs into pools(pool_id) valid).
--- NOTE: pools itself becomes chain-qualified when the Phase-3 indexer ingests a
--- second chain (AGENTS.md "chain-qualified keys before a second chain is indexed").
-CREATE TABLE IF NOT EXISTS pools_v2 (
-    pool_id TEXT PRIMARY KEY NOT NULL,        -- bytes32 as hex string
-    token0_address TEXT NOT NULL,
-    token1_address TEXT NOT NULL,
-    fee INTEGER NOT NULL,                     -- fee tier (e.g. 3000 = 0.3%)
-    tick_spacing INTEGER NOT NULL,
-    hook_address TEXT,                        -- AetherHook address
-    sqrt_price_x96 TEXT NOT NULL,             -- current sqrt price (big number as string)
-    current_tick INTEGER NOT NULL,
-    liquidity TEXT NOT NULL,                  -- total liquidity (big number as string)
-    tvl_usd REAL NOT NULL DEFAULT 0,
-    volume_24h_usd REAL NOT NULL DEFAULT 0,
-    fees_24h_usd REAL NOT NULL DEFAULT 0,
-    is_active INTEGER NOT NULL DEFAULT 1,
-    created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL
-);
-INSERT OR IGNORE INTO pools_v2
-    (pool_id, token0_address, token1_address, fee, tick_spacing, hook_address, sqrt_price_x96, current_tick,
-     liquidity, tvl_usd, volume_24h_usd, fees_24h_usd, is_active, created_at, updated_at)
-  SELECT pool_id, token0_address, token1_address, fee, tick_spacing, hook_address, sqrt_price_x96, current_tick,
-         liquidity, tvl_usd, volume_24h_usd, fees_24h_usd, is_active, created_at, updated_at
-  FROM pools;
-DROP TABLE pools;
-ALTER TABLE pools_v2 RENAME TO pools;
-CREATE INDEX IF NOT EXISTS idx_pools_active ON pools(is_active, tvl_usd DESC);
-CREATE INDEX IF NOT EXISTS idx_pools_tokens ON pools(token0_address, token1_address);
+-- Sanity: no dangling FKs after the rebuild (runs regardless of enforcement mode).
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys = on;

--- a/apps/api/migrations/0003_chain_scoped_tokens.sql
+++ b/apps/api/migrations/0003_chain_scoped_tokens.sql
@@ -136,6 +136,74 @@ ALTER TABLE tokens_chain_scoped RENAME TO tokens;
 CREATE INDEX IF NOT EXISTS idx_tokens_symbol ON tokens(symbol);
 CREATE INDEX IF NOT EXISTS idx_tokens_verified ON tokens(chain_id, is_verified, symbol);
 
+-- Pass 2: restore the pool_id FOREIGN KEYs on transactions / liquidity_positions.
+-- They were only dropped so the pools table could be swapped above; pools now exists
+-- again with pool_id as its primary key, so the references can be reinstated (every
+-- surviving pool_id satisfies them by construction — the foreign_key_check below
+-- proves it). Only the pools → tokens(address) FK is permanently gone, by design:
+-- tokens is now keyed by (chain_id, address), and pool tokens are not guaranteed to
+-- appear in the default token list.
+CREATE TABLE IF NOT EXISTS transactions_final (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tx_hash TEXT UNIQUE NOT NULL,
+    user_address TEXT NOT NULL,
+    pool_id TEXT,                                     -- nullable for non-pool txs
+    tx_type TEXT NOT NULL,                            -- 'swap' | 'add_liquidity' | 'remove_liquidity' | 'create_pool'
+    token_in TEXT,
+    token_out TEXT,
+    amount_in TEXT,                                   -- big number as string
+    amount_out TEXT,                                  -- big number as string
+    amount_usd REAL,
+    gas_used INTEGER,
+    gas_price TEXT,
+    block_number INTEGER NOT NULL,
+    block_timestamp INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',           -- 'pending' | 'confirmed' | 'failed'
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (user_address) REFERENCES users(address),
+    FOREIGN KEY (pool_id) REFERENCES pools(pool_id)
+);
+INSERT OR IGNORE INTO transactions_final
+    (id, tx_hash, user_address, pool_id, tx_type, token_in, token_out, amount_in, amount_out, amount_usd,
+     gas_used, gas_price, block_number, block_timestamp, status, created_at)
+  SELECT id, tx_hash, user_address, pool_id, tx_type, token_in, token_out, amount_in, amount_out, amount_usd,
+         gas_used, gas_price, block_number, block_timestamp, status, created_at
+  FROM transactions;
+DROP TABLE transactions;
+ALTER TABLE transactions_final RENAME TO transactions;
+CREATE INDEX IF NOT EXISTS idx_tx_user ON transactions(user_address, block_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_tx_pool ON transactions(pool_id, block_timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_tx_block ON transactions(block_number DESC);
+CREATE INDEX IF NOT EXISTS idx_tx_status ON transactions(status);
+
+CREATE TABLE IF NOT EXISTS liquidity_positions_final (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_address TEXT NOT NULL,
+    pool_id TEXT NOT NULL,
+    tick_lower INTEGER NOT NULL,
+    tick_upper INTEGER NOT NULL,
+    liquidity TEXT NOT NULL,                          -- LP tokens amount (big number as string)
+    amount0 TEXT NOT NULL,                            -- token0 amount
+    amount1 TEXT NOT NULL,                            -- token1 amount
+    fees_earned_token0 TEXT NOT NULL DEFAULT '0',
+    fees_earned_token1 TEXT NOT NULL DEFAULT '0',
+    is_active INTEGER NOT NULL DEFAULT 1,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    FOREIGN KEY (user_address) REFERENCES users(address),
+    FOREIGN KEY (pool_id) REFERENCES pools(pool_id)
+);
+INSERT OR IGNORE INTO liquidity_positions_final
+    (id, user_address, pool_id, tick_lower, tick_upper, liquidity, amount0, amount1,
+     fees_earned_token0, fees_earned_token1, is_active, created_at, updated_at)
+  SELECT id, user_address, pool_id, tick_lower, tick_upper, liquidity, amount0, amount1,
+         fees_earned_token0, fees_earned_token1, is_active, created_at, updated_at
+  FROM liquidity_positions;
+DROP TABLE liquidity_positions;
+ALTER TABLE liquidity_positions_final RENAME TO liquidity_positions;
+CREATE INDEX IF NOT EXISTS idx_lp_user ON liquidity_positions(user_address, is_active);
+CREATE INDEX IF NOT EXISTS idx_lp_pool ON liquidity_positions(pool_id, is_active);
+
 -- Sanity: no dangling FKs after the rebuild (runs regardless of enforcement mode).
 PRAGMA foreign_key_check;
 PRAGMA foreign_keys = on;

--- a/apps/api/src/db/queries.ts
+++ b/apps/api/src/db/queries.ts
@@ -27,9 +27,9 @@ export const upsertToken = (token: Omit<Token, "createdAt" | "updatedAt">) =>
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient
     yield* sql`
-      INSERT INTO tokens (address, symbol, name, decimals, logo_url, is_verified, is_native, total_supply, created_at, updated_at)
-      VALUES (${token.address}, ${token.symbol}, ${token.name}, ${token.decimals}, ${token.logoUrl}, ${token.isVerified ? 1 : 0}, ${token.isNative ? 1 : 0}, ${token.totalSupply}, ${Date.now()}, ${Date.now()})
-      ON CONFLICT(address) DO UPDATE SET
+      INSERT INTO tokens (chain_id, address, symbol, name, decimals, logo_url, is_verified, is_native, total_supply, created_at, updated_at)
+      VALUES (${token.chainId}, ${token.address}, ${token.symbol}, ${token.name}, ${token.decimals}, ${token.logoUrl}, ${token.isVerified ? 1 : 0}, ${token.isNative ? 1 : 0}, ${token.totalSupply}, ${Date.now()}, ${Date.now()})
+      ON CONFLICT(chain_id, address) DO UPDATE SET
         symbol = excluded.symbol,
         name = excluded.name,
         decimals = excluded.decimals,

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -13,6 +13,7 @@ export interface User {
 }
 
 export interface Token {
+  chainId: number
   address: string
   symbol: string
   name: string
@@ -92,6 +93,7 @@ export interface PriceCache {
  */
 export function rowToToken(row: Record<string, unknown>): Token {
   return {
+    chainId: (row.chain_id as number | undefined) ?? 1,
     address: row.address as string,
     symbol: row.symbol as string,
     name: row.name as string,

--- a/apps/api/src/durable-objects/websocket-hub-do.ts
+++ b/apps/api/src/durable-objects/websocket-hub-do.ts
@@ -1,8 +1,11 @@
 /**
  * AetherDEX WebSocket Hub Durable Object
  *
- * Fan-out hub for live price updates across multiple pools.
- * Single instance handles all price subscriptions, distributes to relevant pool DOs.
+ * Fan-out hub for live per-token price updates. A single instance serves all
+ * price subscriptions (web `PriceTicker` connects to `/ws/prices/:tokenAddress`);
+ * producers (the price-refresh queue pipeline) POST refreshed prices, which are
+ * fanned out as `{ type: "price_update", data: { tokenAddress, price, updatedAt } }`
+ * — the exact envelope the web consumer unwraps.
  */
 
 interface Env {
@@ -12,20 +15,14 @@ interface Env {
 
 interface Subscriber {
   webSocket: WebSocket
-  watchedPools: Set<string>
+  watchedKeys: Set<string>
   connectedAt: number
 }
 
-interface PriceUpdate {
-  poolId: string
-  token0Address: string
-  token1Address: string
-  price0Usd: number
-  price1Usd: number
-  tvlUsd: number
-  volume24hUsd: number
-  blockNumber: number
-  timestamp: number
+interface TokenPriceUpdate {
+  tokenAddress: string
+  price: number
+  updatedAt: number
 }
 
 interface SubscribeMessage {
@@ -45,7 +42,7 @@ export class WebSocketHubDO implements DurableObject {
   // biome-ignore lint/correctness/noUnusedPrivateClassMembers: env holds the CACHE KV binding reserved for Phase-0 WebSocket live-data reads
   private env: Env
   private subscribers: Map<WebSocket, Subscriber> = new Map()
-  private knownPools: Set<string> = new Set()
+  private knownTokens: Set<string> = new Set()
 
   constructor(ctx: DurableObjectState, env: Env) {
     this.ctx = ctx
@@ -67,17 +64,17 @@ export class WebSocketHubDO implements DurableObject {
       this.ctx.acceptWebSocket(server)
       this.subscribers.set(server, {
         webSocket: server,
-        watchedPools: new Set(),
+        watchedKeys: new Set(),
         connectedAt: Date.now(),
       })
 
       return new Response(null, { status: 101, webSocket: client })
     }
 
-    // HTTP: broadcast price update (used by queue consumers / cron)
+    // HTTP: broadcast a refreshed token price (called by the price-refresh queue pipeline)
     if (request.method === "POST" && url.pathname === "/price") {
-      const update = (await request.json()) as PriceUpdate
-      this.knownPools.add(update.poolId)
+      const update = (await request.json()) as TokenPriceUpdate
+      this.knownTokens.add(update.tokenAddress)
       this.broadcastPrice(update)
       return new Response(JSON.stringify({ ok: true, subscribers: this.subscribers.size }), {
         headers: { "Content-Type": "application/json" },
@@ -89,8 +86,8 @@ export class WebSocketHubDO implements DurableObject {
       return new Response(
         JSON.stringify({
           subscribers: this.subscribers.size,
-          knownPools: this.knownPools.size,
-          poolIds: Array.from(this.knownPools),
+          knownTokens: this.knownTokens.size,
+          tokenAddresses: Array.from(this.knownTokens),
         }),
         { headers: { "Content-Type": "application/json" } },
       )
@@ -113,18 +110,18 @@ export class WebSocketHubDO implements DurableObject {
           break
         case "subscribe":
           if (msg.poolId) {
-            subscriber.watchedPools.add(msg.poolId)
+            subscriber.watchedKeys.add(msg.poolId)
             this.sendToSocket(ws, { type: "subscribed", data: { poolId: msg.poolId } })
           }
           break
         case "unsubscribe":
           if (msg.poolId) {
-            subscriber.watchedPools.delete(msg.poolId)
+            subscriber.watchedKeys.delete(msg.poolId)
             this.sendToSocket(ws, { type: "unsubscribed", data: { poolId: msg.poolId } })
           }
           break
         case "list_pools":
-          this.sendToSocket(ws, { type: "pool_list", pools: Array.from(this.knownPools) })
+          this.sendToSocket(ws, { type: "pool_list", pools: Array.from(this.knownTokens) })
           break
       }
     } catch (err) {
@@ -160,12 +157,13 @@ export class WebSocketHubDO implements DurableObject {
     }
   }
 
-  private broadcastPrice(update: PriceUpdate): void {
+  private broadcastPrice(update: TokenPriceUpdate): void {
     const message: HubMessage = { type: "price_update", data: update }
     const data = JSON.stringify(message)
     for (const [ws, subscriber] of this.subscribers) {
-      // Send to subscribers watching this pool, or all if they watch nothing (global listeners)
-      if (subscriber.watchedPools.has(update.poolId) || subscriber.watchedPools.size === 0) {
+      // Fan out to subscribers watching this token, or to global listeners
+      // (no watched keys — e.g. web PriceTicker, which filters client-side).
+      if (subscriber.watchedKeys.has(update.tokenAddress) || subscriber.watchedKeys.size === 0) {
         try {
           ws.send(data)
         } catch (err) {

--- a/apps/api/src/durable-objects/websocket-hub-do.ts
+++ b/apps/api/src/durable-objects/websocket-hub-do.ts
@@ -19,6 +19,11 @@ interface Subscriber {
   connectedAt: number
 }
 
+/** Persisted per-socket state (survives hibernation via the DO attachment). */
+interface WatchAttachment {
+  readonly watchedKeys: readonly string[]
+}
+
 interface TokenPriceUpdate {
   tokenAddress: string
   price: number
@@ -62,6 +67,7 @@ export class WebSocketHubDO implements DurableObject {
       const [client, server] = Object.values(webSocketPair) as [WebSocket, WebSocket]
 
       this.ctx.acceptWebSocket(server)
+      server.serializeAttachment({ watchedKeys: [] } satisfies WatchAttachment)
       this.subscribers.set(server, {
         webSocket: server,
         watchedKeys: new Set(),
@@ -98,6 +104,7 @@ export class WebSocketHubDO implements DurableObject {
 
   async webSocketMessage(ws: WebSocket, rawMessage: string | ArrayBuffer): Promise<void> {
     try {
+      this.hydrateSubscribers()
       const msg = JSON.parse(
         typeof rawMessage === "string" ? rawMessage : new TextDecoder().decode(rawMessage),
       ) as SubscribeMessage
@@ -111,12 +118,14 @@ export class WebSocketHubDO implements DurableObject {
         case "subscribe":
           if (msg.poolId) {
             subscriber.watchedKeys.add(msg.poolId)
+            this.persistWatched(ws, subscriber)
             this.sendToSocket(ws, { type: "subscribed", data: { poolId: msg.poolId } })
           }
           break
         case "unsubscribe":
           if (msg.poolId) {
             subscriber.watchedKeys.delete(msg.poolId)
+            this.persistWatched(ws, subscriber)
             this.sendToSocket(ws, { type: "unsubscribed", data: { poolId: msg.poolId } })
           }
           break
@@ -148,6 +157,33 @@ export class WebSocketHubDO implements DurableObject {
     }
   }
 
+  /**
+   * Rebuild the in-memory subscriber map after hibernation. The Hibernation API keeps
+   * accepted sockets connected across hibernation, but this DO's in-memory state (the
+   * subscribers map) does not survive it — a woken instance (e.g. a price-refresh POST
+   * five minutes later) would otherwise broadcast to nobody. `getWebSockets()` returns
+   * the still-connected sockets and the attachment carries their watched keys.
+   */
+  private hydrateSubscribers(): void {
+    for (const ws of this.ctx.getWebSockets()) {
+      if (this.subscribers.has(ws)) continue
+      const attachment = ws.deserializeAttachment() as WatchAttachment | null
+      this.subscribers.set(ws, {
+        webSocket: ws,
+        watchedKeys: new Set(attachment?.watchedKeys ?? []),
+        connectedAt: Date.now(),
+      })
+    }
+  }
+
+  private persistWatched(ws: WebSocket, subscriber: Subscriber): void {
+    try {
+      ws.serializeAttachment({ watchedKeys: [...subscriber.watchedKeys] } satisfies WatchAttachment)
+    } catch (err) {
+      console.error("Failed to persist watched keys:", err)
+    }
+  }
+
   private sendToSocket(ws: WebSocket, msg: HubMessage): void {
     try {
       ws.send(JSON.stringify(msg))
@@ -158,6 +194,7 @@ export class WebSocketHubDO implements DurableObject {
   }
 
   private broadcastPrice(update: TokenPriceUpdate): void {
+    this.hydrateSubscribers()
     const message: HubMessage = { type: "price_update", data: update }
     const data = JSON.stringify(message)
     for (const [ws, subscriber] of this.subscribers) {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -134,9 +134,12 @@ app.get("/ws/orderbook/:poolId", async (c) => {
   if (!/^0x[a-fA-F0-9]{64}$/.test(poolId)) {
     return c.json({ error: "Invalid poolId (must be 0x + 64 hex chars)" }, 400)
   }
+  // Canonicalize BEFORE selecting the DO / forwarding the key: the same bytes32
+  // pool spelled in different casings must map to ONE order book + snapshot key.
+  const canonicalPoolId = poolId.toLowerCase()
   const url = new URL(c.req.url)
-  url.searchParams.set("poolId", poolId)
-  const id = c.env.ORDER_BOOK.idFromName(poolId)
+  url.searchParams.set("poolId", canonicalPoolId)
+  const id = c.env.ORDER_BOOK.idFromName(canonicalPoolId)
   return c.env.ORDER_BOOK.get(id).fetch(
     new Request(url.toString(), { method: c.req.method, headers: c.req.raw.headers }),
   )
@@ -173,6 +176,7 @@ const worker = {
       DB: env.DB,
       CACHE: env.CACHE,
       STORAGE: env.STORAGE,
+      WEBSOCKET_HUB: env.WEBSOCKET_HUB,
       CHAIN_ID: env.CHAIN_ID,
     })
   },

--- a/apps/api/src/routes/tokens.ts
+++ b/apps/api/src/routes/tokens.ts
@@ -50,7 +50,10 @@ const tokenListLayer = (env: Bindings) => {
  * GET /api/v1/tokens?verified=true&search=eth&limit=100
  */
 tokens.get("/", async (c) => {
-  const limit = Math.min(Number.parseInt(c.req.query("limit") ?? "100", 10), 500)
+  // Non-numeric `limit` must fall back to the default (100), not NaN — NaN would
+  // propagate to slice(0, NaN) → slice(0, 0) and silently return zero tokens.
+  const parsedLimit = Number.parseInt(c.req.query("limit") ?? "100", 10)
+  const limit = Math.min(Number.isNaN(parsedLimit) ? 100 : parsedLimit, 500)
   const search = c.req.query("search")
 
   try {

--- a/apps/api/src/routes/tokens.ts
+++ b/apps/api/src/routes/tokens.ts
@@ -50,10 +50,11 @@ const tokenListLayer = (env: Bindings) => {
  * GET /api/v1/tokens?verified=true&search=eth&limit=100
  */
 tokens.get("/", async (c) => {
-  // Non-numeric `limit` must fall back to the default (100), not NaN — NaN would
-  // propagate to slice(0, NaN) → slice(0, 0) and silently return zero tokens.
+  // Non-numeric or negative `limit` must fall back to the default (100): NaN would
+  // propagate to slice(0, NaN) → slice(0, 0) (silent empty result), and a negative
+  // value would become slice(0, -n), which silently drops the last entries.
   const parsedLimit = Number.parseInt(c.req.query("limit") ?? "100", 10)
-  const limit = Math.min(Number.isNaN(parsedLimit) ? 100 : parsedLimit, 500)
+  const limit = Math.min(Number.isNaN(parsedLimit) || parsedLimit < 0 ? 100 : parsedLimit, 500)
   const search = c.req.query("search")
 
   try {

--- a/apps/api/src/services/chain-state-reader.ts
+++ b/apps/api/src/services/chain-state-reader.ts
@@ -17,7 +17,7 @@
 import { Token } from "@uniswap/sdk-core"
 import { Pool } from "@uniswap/v4-sdk"
 import { Context, Effect, Layer } from "effect"
-import { createPublicClient, http } from "viem"
+import { createPublicClient, getAddress, http, isAddress } from "viem"
 import type { InitializedTick, PoolChainState, PoolKeyParams } from "./quote-engine"
 
 // ─── Service interface ──────────────────────────────────────────────────────
@@ -25,7 +25,7 @@ import type { InitializedTick, PoolChainState, PoolKeyParams } from "./quote-eng
 export class OnChainReadError {
   readonly _tag = "OnChainReadError"
   constructor(
-    readonly reason: "not_configured" | "rpc_error" | "pool_not_initialized",
+    readonly reason: "not_configured" | "rpc_error" | "pool_not_initialized" | "invalid_pool_key",
     readonly message: string,
   ) {}
 }
@@ -124,8 +124,14 @@ export const unconfiguredChainStateReaderLayer: Layer.Layer<ChainStateReader> = 
 
 /** Deterministic pool id used to key mock state and to query the StateView. */
 export function poolIdOf(chainId: number, key: PoolKeyParams): string {
-  const token0 = new Token(chainId, key.token0, 18)
-  const token1 = new Token(chainId, key.token1, 18)
+  // Validate + EIP-55-normalize BEFORE the Uniswap `Token` constructor, which throws
+  // (or rejects non-checksummed input) on malformed addresses. Callers that run this
+  // inside Effect.try map the rejection to OnChainReadError("invalid_pool_key") instead
+  // of letting it escape as an uncaught constructor exception.
+  if (!isAddress(key.token0)) throw new Error(`token0 is not a valid address: ${key.token0}`)
+  if (!isAddress(key.token1)) throw new Error(`token1 is not a valid address: ${key.token1}`)
+  const token0 = new Token(chainId, getAddress(key.token0), 18)
+  const token1 = new Token(chainId, getAddress(key.token1), 18)
   return Pool.getPoolId(token0, token1, key.fee, key.tickSpacing, key.hooks)
 }
 
@@ -141,7 +147,14 @@ export const makeStateViewReaderLayer = (config: StateViewReaderConfig): Layer.L
 
       const getPoolState = (key: PoolKeyParams): Effect.Effect<PoolChainState, OnChainReadError> =>
         Effect.gen(function* () {
-          const poolId = poolIdOf(config.chainId, key) as `0x${string}`
+          const poolId = (yield* Effect.try({
+            try: () => poolIdOf(config.chainId, key),
+            catch: (e) =>
+              new OnChainReadError(
+                "invalid_pool_key",
+                `Invalid pool key: ${e instanceof Error ? e.message : String(e)}`,
+              ),
+          })) as `0x${string}`
 
           // 1. Spot state: slot0 + current liquidity
           const [slot0, liquidity] = yield* Effect.tryPromise({
@@ -170,11 +183,17 @@ export const makeStateViewReaderLayer = (config: StateViewReaderConfig): Layer.L
             return yield* Effect.fail(new OnChainReadError("pool_not_initialized", `Pool ${poolId} is not initialized`))
           }
 
-          // 2. Initialized-tick window around the active tick (Phase-3 indexer replaces this scan)
-          const candidates: number[] = []
+          // 2. Initialized-tick window around the active tick (Phase-3 indexer replaces this scan).
+          //    Anchored to tick-spacing BOUNDARIES: initialized ticks are always multiples of
+          //    tickSpacing, but the active tick usually is NOT — scanning `tick ± k·spacing`
+          //    would probe invalid ticks (same remainder as `tick`) and miss every crossing.
+          //    Anchor to the boundary at/below the active tick and include it.
+          const spacing = key.tickSpacing
+          const anchor = Math.floor(tick / spacing) * spacing
+          const candidates: number[] = [anchor]
           for (let k = 1; k <= scan; k += 1) {
-            candidates.push(tick - k * key.tickSpacing)
-            candidates.push(tick + k * key.tickSpacing)
+            candidates.push(anchor - k * spacing)
+            candidates.push(anchor + k * spacing)
           }
 
           // Parallel per-tick `getTickLiquidity` probes (Phase-3 indexer replaces
@@ -203,7 +222,11 @@ export const makeStateViewReaderLayer = (config: StateViewReaderConfig): Layer.L
             .filter((t) => t.liquidityNet !== 0n)
             .sort((a, b) => a.tick - b.tick)
 
-          return { sqrtPriceX96, tick, liquidity, initializedTicks }
+          // The exact tick range this snapshot verified. Simulations that exit it are
+          // rejected by the quote engine (ticks outside are unverified, not "uninitialized").
+          const verifiedTickWindow: readonly [number, number] = [anchor - scan * spacing, anchor + scan * spacing]
+
+          return { sqrtPriceX96, tick, liquidity, initializedTicks, verifiedTickWindow }
         })
 
       return { getPoolState }

--- a/apps/api/src/services/quote-engine.ts
+++ b/apps/api/src/services/quote-engine.ts
@@ -47,6 +47,15 @@ export interface PoolChainState {
   readonly liquidity: bigint
   /** Initialized ticks around the active price (from the quoter / StateView / indexer). */
   readonly initializedTicks: readonly InitializedTick[]
+  /**
+   * Inclusive [minTick, maxTick] range that `initializedTicks` was VERIFIED over.
+   * When present, simulations whose terminal tick exits this window are rejected
+   * (see `price_out_of_range`): outside the window, "no initialized tick found"
+   * means "unverified", NOT "uninitialized", so continuing would quote a wrong
+   * amount. Absent → the tick set is authoritative over the whole range
+   * (full-table providers: Phase-3 indexer, unit-test mocks).
+   */
+  readonly verifiedTickWindow?: readonly [number, number]
 }
 
 export interface QuoteResult {
@@ -68,7 +77,7 @@ export interface QuoteResult {
 export class QuoteEngineError extends Error {
   readonly _tag = "QuoteEngineError"
   constructor(
-    readonly reason: "invalid_amount" | "no_liquidity" | "simulation_failed",
+    readonly reason: "invalid_amount" | "no_liquidity" | "simulation_failed" | "price_out_of_range",
     message: string,
   ) {
     super(message)
@@ -88,8 +97,10 @@ export const ZERO_HOOK_ADDRESS = "0x0000000000000000000000000000000000000000"
  * table's `liquidityNet` to sum to zero — the full universe of ticks is only
  * available from the Phase-3 indexer, while G2 reads a window around the
  * active price from `StateView.getTickLiquidity`. Ticks outside the known set
- * are treated as uninitialized (no liquidity change), which makes quotes for
- * swaps that leave the window conservatively approximate rather than wrong.
+ * are treated as uninitialized (no liquidity change). The simulation rejects
+ * (rather than approximates) any swap whose terminal tick leaves the state's
+ * `verifiedTickWindow`, so this assumption is never applied to unverified
+ * territory — see `simulateExactInputSwap`.
  */
 class InMemoryTickDataProvider implements TickDataProvider {
   private readonly ticks: readonly Tick[]
@@ -217,6 +228,18 @@ export async function simulateExactInputSwap(params: SimulateExactInputParams): 
 
   // ── Crossed initialized ticks ──
   const tickAfter = poolAfter.tickCurrent
+
+  // The simulated price left the tick range the StateView snapshot verified: ticks
+  // beyond it were never read, so the accumulated liquidityNet cannot be trusted in
+  // EITHER direction. Reject rather than emit a non-conservative approximate quote.
+  const window = state.verifiedTickWindow
+  if (window && (tickAfter < window[0] || tickAfter > window[1])) {
+    throw new QuoteEngineError(
+      "price_out_of_range",
+      `Swap exits the verified tick window [${window[0]}, ${window[1]}] (tickAfter ${tickAfter}) — retry with a smaller amount`,
+    )
+  }
+
   const crossed = state.initializedTicks.filter((t) =>
     zeroForOne ? t.tick <= state.tick && t.tick > tickAfter : t.tick > state.tick && t.tick <= tickAfter,
   ).length

--- a/apps/api/src/services/swap.service.ts
+++ b/apps/api/src/services/swap.service.ts
@@ -11,9 +11,9 @@
  * makes the V4 path strict; `legacy` forces the old approximation.
  */
 
-import { Context, Effect, Layer } from "effect"
+import { Context, Effect, Layer, Result } from "effect"
 import { type Address, encodeFunctionData, getAddress, type Hex } from "viem"
-import { ChainStateReader, OnChainReadError } from "./chain-state-reader"
+import { ChainStateReader } from "./chain-state-reader"
 import { PoolService } from "./pool.service"
 import {
   type PoolChainState,
@@ -49,7 +49,7 @@ export interface SwapQuoteParams {
 export class SwapQuoteError {
   readonly _tag = "SwapQuoteError"
   constructor(
-    readonly reason: "no_pool" | "insufficient_liquidity" | "invalid_amount" | "expired",
+    readonly reason: "no_pool" | "insufficient_liquidity" | "invalid_amount" | "expired" | "price_out_of_range",
     readonly message: string,
   ) {}
 }
@@ -232,17 +232,21 @@ const makeSwapService = (deps: SwapServiceDeps, pools: PoolService, reader: Chai
         tickSpacing: meta.tickSpacing,
         hooks: meta.hookAddress ?? ZERO_HOOK_ADDRESS,
       }
-      const state: PoolChainState = yield* reader
-        .getPoolState(key)
-        .pipe(
-          Effect.mapError(
-            (e) =>
-              new SwapQuoteError(
-                "no_pool",
-                e instanceof OnChainReadError ? `On-chain read failed (${e.reason}): ${e.message}` : String(e),
-              ),
-          ),
-        )
+      // Rollback path (auto mode ONLY): when on-chain reads are not wired yet
+      // (pre-G5 `not_configured`), degrade to the legacy constant-product quote at
+      // the read step itself. Later failures (zero in-range liquidity, simulation
+      // error, quote leaving the verified tick window) mean the V4 quote is
+      // authoritative and NEGATIVE — silently substituting a plausible-looking
+      // constant-product number would quote swaps that cannot execute.
+      const stateRead = yield* Effect.result(reader.getPoolState(key))
+      if (Result.isFailure(stateRead)) {
+        const e = stateRead.failure
+        if (mode === "auto" && e.reason === "not_configured") {
+          return yield* quoteLegacy(params, amountIn, meta)
+        }
+        return yield* Effect.fail(new SwapQuoteError("no_pool", `On-chain read failed (${e.reason}): ${e.message}`))
+      }
+      const state: PoolChainState = stateRead.success
 
       const result = yield* Effect.tryPromise({
         try: () => simulateExactInputSwap({ chainId, key, state, zeroForOne, amountIn }),
@@ -253,6 +257,9 @@ const makeSwapService = (deps: SwapServiceDeps, pools: PoolService, reader: Chai
           }
           if (err?.reason === "invalid_amount") {
             return new SwapQuoteError("invalid_amount", err.message)
+          }
+          if (err?.reason === "price_out_of_range") {
+            return new SwapQuoteError("price_out_of_range", err.message)
           }
           return new SwapQuoteError("no_pool", err?.message ?? String(e))
         },
@@ -304,16 +311,9 @@ const makeSwapService = (deps: SwapServiceDeps, pools: PoolService, reader: Chai
         return yield* quoteLegacy(params, amountIn, meta)
       }
 
-      return yield* quoteV4(params, amountIn, zeroForOne, meta).pipe(
-        Effect.catch((err) => {
-          // Rollback path: in auto mode, degrade to the legacy approximation
-          // when the V4 path cannot read on-chain state (e.g. undeployed pre-G5).
-          if (mode === "auto") {
-            return quoteLegacy(params, amountIn, meta)
-          }
-          return Effect.fail(err)
-        }),
-      )
+      // quoteV4 itself performs the (restricted) legacy rollback when — and only
+      // when — the chain-state reader reports `not_configured` in auto mode.
+      return yield* quoteV4(params, amountIn, zeroForOne, meta)
     })
 
   const buildCalldata = (

--- a/apps/api/src/services/token-list.service.ts
+++ b/apps/api/src/services/token-list.service.ts
@@ -197,10 +197,11 @@ const makeTokenListService = Effect.gen(function* () {
       .pipe(Effect.catch(() => Effect.succeed([] as TokenInfo[])))
 
   const applyOptions = (tokens: readonly TokenInfo[], options?: TokenSearchOptions): TokenInfo[] => {
-    // Defensive: a non-finite limit (e.g. NaN from a bad caller) must fall back to the
-    // default, not slice(0, NaN) → an empty result.
+    // Defensive: a non-finite limit (e.g. NaN from a bad caller) or a negative one must
+    // fall back to the default — NaN slices to an empty set (slice(0, NaN) → slice(0, 0))
+    // and a negative value silently drops trailing entries (slice(0, -n)).
     const rawLimit = options?.limit
-    const limit = Math.min(rawLimit === undefined || !Number.isFinite(rawLimit) ? 100 : rawLimit, 500)
+    const limit = Math.min(rawLimit === undefined || !Number.isFinite(rawLimit) || rawLimit < 0 ? 100 : rawLimit, 500)
     return tokens.filter((t) => matchesQuery(t, options?.query)).slice(0, limit)
   }
 

--- a/apps/api/src/services/token-list.service.ts
+++ b/apps/api/src/services/token-list.service.ts
@@ -81,8 +81,15 @@ export const TokenListService = Context.Service<TokenListService>("@aetherdex/To
 
 const kvKey = (chainId: number) => `token-list:v1:chain:${chainId}`
 
-function toTokenInfo(token: ValidatedToken): TokenInfo {
+/** KV cache payload: tokens + the single refresh-time stamp reused by every cached read. */
+interface TokenListCachePayload {
+  readonly asOf: number
+  readonly tokens: readonly ValidatedToken[]
+}
+
+function toTokenInfo(token: ValidatedToken, chainId: number, asOf: number): TokenInfo {
   return {
+    chainId,
     address: token.address,
     symbol: token.symbol,
     name: token.name,
@@ -91,8 +98,8 @@ function toTokenInfo(token: ValidatedToken): TokenInfo {
     isVerified: true,
     isNative: false,
     totalSupply: null,
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
+    createdAt: asOf,
+    updatedAt: asOf,
   }
 }
 
@@ -116,21 +123,24 @@ const makeTokenListService = Effect.gen(function* () {
       try: async () => {
         const raw = await deps.kv.get(kvKey(deps.chainId))
         if (!raw) return null
-        const parsed = JSON.parse(raw) as ValidatedToken[]
-        if (!Array.isArray(parsed)) return null
-        return parsed.map(toTokenInfo)
+        const parsed = JSON.parse(raw) as TokenListCachePayload
+        // Accept only the versioned envelope; legacy/foreign payloads are treated as a miss.
+        if (!parsed || typeof parsed.asOf !== "number" || !Array.isArray(parsed.tokens)) return null
+        return parsed.tokens.map((t) => toTokenInfo(t, deps.chainId, parsed.asOf))
       },
       catch: (e) => new TokenListError(`KV cache read failed: ${String(e)}`),
     })
 
-  const writeThroughD1 = (tokens: readonly ValidatedToken[]): Effect.Effect<void, never> =>
+  const writeThroughD1 = (tokens: readonly ValidatedToken[], asOf: number): Effect.Effect<void, never> =>
     Effect.forEach(
       tokens,
       (token) =>
+        // Chain-scoped: tokens are keyed by (chain_id, address) — the same address on two
+        // chains is two different tokens and must not overwrite each other's cache rows.
         sql`
-          INSERT INTO tokens (address, symbol, name, decimals, logo_url, is_verified, is_native, total_supply, created_at, updated_at)
-          VALUES (${token.address}, ${token.symbol}, ${token.name}, ${token.decimals}, ${token.logoURI}, 1, 0, NULL, ${Date.now()}, ${Date.now()})
-          ON CONFLICT(address) DO UPDATE SET
+          INSERT INTO tokens (chain_id, address, symbol, name, decimals, logo_url, is_verified, is_native, total_supply, created_at, updated_at)
+          VALUES (${deps.chainId}, ${token.address}, ${token.symbol}, ${token.name}, ${token.decimals}, ${token.logoURI}, 1, 0, NULL, ${asOf}, ${asOf})
+          ON CONFLICT(chain_id, address) DO UPDATE SET
             symbol = excluded.symbol,
             name = excluded.name,
             decimals = excluded.decimals,
@@ -158,28 +168,41 @@ const makeTokenListService = Effect.gen(function* () {
         return yield* Effect.fail(new TokenListError(`Token list validation failed: ${message}`))
       }
 
+      // Stamp the refresh time ONCE: every cached read reuses it, so responses report when
+      // the list was actually cached/refreshed — never a fabricated per-request Date.now().
+      const asOf = Date.now()
+
       yield* Effect.tryPromise({
-        try: () => deps.kv.put(kvKey(deps.chainId), JSON.stringify(tokens), { expirationTtl: deps.cacheTtlSeconds }),
+        try: () =>
+          deps.kv.put(kvKey(deps.chainId), JSON.stringify({ asOf, tokens } satisfies TokenListCachePayload), {
+            expirationTtl: deps.cacheTtlSeconds,
+          }),
         catch: () => undefined,
       }).pipe(Effect.catch(() => Effect.void))
 
-      yield* writeThroughD1(tokens)
+      yield* writeThroughD1(tokens, asOf)
 
-      return tokens.map(toTokenInfo)
+      return tokens.map((t) => toTokenInfo(t, deps.chainId, asOf))
     })
 
   const readD1Cache = (): Effect.Effect<TokenInfo[], never> =>
+    // Chain-scoped read: never serve another chain's tokens from the shared table.
     sql`
       SELECT * FROM tokens
-      WHERE is_verified = 1
+      WHERE is_verified = 1 AND chain_id = ${deps.chainId}
       ORDER BY symbol ASC
       LIMIT 500
     `
       .pipe(Effect.map((rows) => rows.map((r) => rowToToken(r as Record<string, unknown>))))
       .pipe(Effect.catch(() => Effect.succeed([] as TokenInfo[])))
 
-  const applyOptions = (tokens: readonly TokenInfo[], options?: TokenSearchOptions): TokenInfo[] =>
-    tokens.filter((t) => matchesQuery(t, options?.query)).slice(0, Math.min(options?.limit ?? 100, 500))
+  const applyOptions = (tokens: readonly TokenInfo[], options?: TokenSearchOptions): TokenInfo[] => {
+    // Defensive: a non-finite limit (e.g. NaN from a bad caller) must fall back to the
+    // default, not slice(0, NaN) → an empty result.
+    const rawLimit = options?.limit
+    const limit = Math.min(rawLimit === undefined || !Number.isFinite(rawLimit) ? 100 : rawLimit, 500)
+    return tokens.filter((t) => matchesQuery(t, options?.query)).slice(0, limit)
+  }
 
   /** KV cache → fresh fetch (re-caching) → D1 cache; fail only if all miss. */
   const resolveTokens = (): Effect.Effect<TokenInfo[], TokenListError> =>

--- a/apps/api/src/services/token.service.ts
+++ b/apps/api/src/services/token.service.ts
@@ -57,17 +57,28 @@ export interface TokenService {
 
 export const TokenService = Context.Service<TokenService>("@aetherdex/TokenService")
 
+// --- Dependencies ---
+
+/** The current chain: every tokens-table read must be scoped to it (tokens are keyed by (chain_id, address)). */
+export interface TokenServiceDeps {
+  readonly chainId: number
+}
+
+export const TokenServiceDeps = Context.Service<TokenServiceDeps>("@aetherdex/TokenServiceDeps")
+
 // --- D1-backed implementation ---
 
 const makeTokenService = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient
+  const deps = yield* TokenServiceDeps
 
   const getToken = (address: string): Effect.Effect<TokenInfo | null, TokenReadError, never> =>
     Effect.gen(function* () {
-      const rows = (yield* sql`SELECT * FROM tokens WHERE address = ${address}`) as unknown as readonly Record<
-        string,
-        unknown
-      >[]
+      const rows =
+        (yield* sql`SELECT * FROM tokens WHERE address = ${address} AND chain_id = ${deps.chainId}`) as unknown as readonly Record<
+          string,
+          unknown
+        >[]
       if (rows.length === 0) return null
       return rowToToken(rows[0] as Record<string, unknown>)
     }).pipe(Effect.catch((error) => Effect.fail(new TokenReadError(String(error)))))
@@ -84,14 +95,14 @@ const makeTokenService = Effect.gen(function* () {
         const searchPattern = `%${search.toLowerCase()}%`
         rows = (yield* sql`
           SELECT * FROM tokens
-          WHERE is_verified = 1 AND (LOWER(symbol) LIKE ${searchPattern} OR LOWER(name) LIKE ${searchPattern})
+          WHERE chain_id = ${deps.chainId} AND is_verified = 1 AND (LOWER(symbol) LIKE ${searchPattern} OR LOWER(name) LIKE ${searchPattern})
           ORDER BY symbol ASC
           LIMIT ${limit}
         `) as unknown as readonly Record<string, unknown>[]
       } else if (verified === true) {
         rows = (yield* sql`
           SELECT * FROM tokens
-          WHERE is_verified = 1
+          WHERE chain_id = ${deps.chainId} AND is_verified = 1
           ORDER BY symbol ASC
           LIMIT ${limit}
         `) as unknown as readonly Record<string, unknown>[]
@@ -99,13 +110,14 @@ const makeTokenService = Effect.gen(function* () {
         const searchPattern = `%${search.toLowerCase()}%`
         rows = (yield* sql`
           SELECT * FROM tokens
-          WHERE LOWER(symbol) LIKE ${searchPattern} OR LOWER(name) LIKE ${searchPattern}
+          WHERE chain_id = ${deps.chainId} AND (LOWER(symbol) LIKE ${searchPattern} OR LOWER(name) LIKE ${searchPattern})
           ORDER BY is_verified DESC, symbol ASC
           LIMIT ${limit}
         `) as unknown as readonly Record<string, unknown>[]
       } else {
         rows = (yield* sql`
           SELECT * FROM tokens
+          WHERE chain_id = ${deps.chainId}
           ORDER BY is_verified DESC, symbol ASC
           LIMIT ${limit}
         `) as unknown as readonly Record<string, unknown>[]
@@ -120,7 +132,7 @@ const makeTokenService = Effect.gen(function* () {
       const searchPattern = `%${query.toLowerCase()}%`
       const rows = (yield* sql`
         SELECT * FROM tokens
-        WHERE LOWER(symbol) LIKE ${searchPattern} OR LOWER(name) LIKE ${searchPattern}
+        WHERE chain_id = ${deps.chainId} AND (LOWER(symbol) LIKE ${searchPattern} OR LOWER(name) LIKE ${searchPattern})
         ORDER BY is_verified DESC, symbol ASC
         LIMIT 50
       `) as unknown as readonly Record<string, unknown>[]
@@ -131,7 +143,7 @@ const makeTokenService = Effect.gen(function* () {
     Effect.gen(function* () {
       const rows = (yield* sql`
         SELECT * FROM tokens
-        WHERE is_verified = 1
+        WHERE chain_id = ${deps.chainId} AND is_verified = 1
         ORDER BY symbol ASC
         LIMIT 100
       `) as unknown as readonly Record<string, unknown>[]

--- a/apps/api/src/services/token.service.ts
+++ b/apps/api/src/services/token.service.ts
@@ -10,6 +10,7 @@ import { rowToToken } from "../db/schema"
 // --- Types ---
 
 export interface TokenInfo {
+  chainId: number
   address: string
   symbol: string
   name: string
@@ -140,9 +141,9 @@ const makeTokenService = Effect.gen(function* () {
   const upsertToken = (token: Omit<TokenInfo, "createdAt" | "updatedAt">): Effect.Effect<void, never, never> =>
     Effect.gen(function* () {
       yield* sql`
-        INSERT INTO tokens (address, symbol, name, decimals, logo_url, is_verified, is_native, total_supply, created_at, updated_at)
-        VALUES (${token.address}, ${token.symbol}, ${token.name}, ${token.decimals}, ${token.logoUrl}, ${token.isVerified ? 1 : 0}, ${token.isNative ? 1 : 0}, ${token.totalSupply}, ${Date.now()}, ${Date.now()})
-        ON CONFLICT(address) DO UPDATE SET
+        INSERT INTO tokens (chain_id, address, symbol, name, decimals, logo_url, is_verified, is_native, total_supply, created_at, updated_at)
+        VALUES (${token.chainId}, ${token.address}, ${token.symbol}, ${token.name}, ${token.decimals}, ${token.logoUrl}, ${token.isVerified ? 1 : 0}, ${token.isNative ? 1 : 0}, ${token.totalSupply}, ${Date.now()}, ${Date.now()})
+        ON CONFLICT(chain_id, address) DO UPDATE SET
           symbol = excluded.symbol,
           name = excluded.name,
           decimals = excluded.decimals,

--- a/apps/api/src/workers/cron-handler.ts
+++ b/apps/api/src/workers/cron-handler.ts
@@ -76,10 +76,14 @@ async function refreshTopPools(env: CronEnv): Promise<void> {
 }
 
 async function enqueuePriceRefresh(env: CronEnv): Promise<void> {
-  // Refresh verified tokens every 5 minutes
-  const tokens = await env.DB.prepare("SELECT address FROM tokens WHERE is_verified = 1 LIMIT 200").all<{
-    address: string
-  }>()
+  // Refresh verified tokens every 5 minutes — scoped to this chain: tokens are keyed
+  // by (chain_id, address) and another chain's tokens must not be refreshed here.
+  const chainId = Number.parseInt(env.CHAIN_ID, 10)
+  const tokens = await env.DB.prepare("SELECT address FROM tokens WHERE is_verified = 1 AND chain_id = ? LIMIT 200")
+    .bind(Number.isNaN(chainId) ? 1 : chainId)
+    .all<{
+      address: string
+    }>()
 
   if (!tokens.results || tokens.results.length === 0) return
 

--- a/apps/api/src/workers/queue-handler.ts
+++ b/apps/api/src/workers/queue-handler.ts
@@ -27,6 +27,7 @@ interface QueueEnv {
   DB: D1Database
   CACHE: KVNamespace
   STORAGE: R2Bucket
+  WEBSOCKET_HUB: DurableObjectNamespace
   CHAIN_ID: string
 }
 
@@ -64,19 +65,32 @@ export const processQueueBatch = async (batch: MessageBatch<unknown>, env: Queue
 
 async function handlePriceRefresh(
   msg: PriceRefreshMessage,
-  env: { CACHE: KVNamespace; CHAIN_ID: string },
+  env: { CACHE: KVNamespace; WEBSOCKET_HUB: DurableObjectNamespace; CHAIN_ID: string },
 ): Promise<void> {
   console.log(`Refreshing prices for ${msg.tokens.length} tokens`)
+
+  const hub = env.WEBSOCKET_HUB.get(env.WEBSOCKET_HUB.idFromName("price-hub"))
 
   for (const token of msg.tokens) {
     try {
       // Fetch from external price feed
       const priceUsd = await fetchTokenPrice(token, env.CHAIN_ID)
+      const updatedAt = Date.now()
 
       // Store in KV with 60s TTL
-      await env.CACHE.put(`price:${token}`, JSON.stringify({ tokenAddress: token, priceUsd, updatedAt: Date.now() }), {
+      await env.CACHE.put(`price:${token}`, JSON.stringify({ tokenAddress: token, priceUsd, updatedAt }), {
         expirationTtl: 60,
       })
+
+      // Publish the refresh to the WebSocket hub so connected clients (PriceTicker)
+      // actually receive live updates — without this the /ws/prices route is only a
+      // handshake and subscribers never get a price.
+      await hub.fetch(
+        new Request("http://price-hub/price", {
+          method: "POST",
+          body: JSON.stringify({ tokenAddress: token, price: priceUsd, updatedAt }),
+        }),
+      )
     } catch (error) {
       console.error(`Failed to refresh price for ${token}:`, error)
     }

--- a/apps/api/src/workers/queue-handler.ts
+++ b/apps/api/src/workers/queue-handler.ts
@@ -84,13 +84,17 @@ async function handlePriceRefresh(
 
       // Publish the refresh to the WebSocket hub so connected clients (PriceTicker)
       // actually receive live updates — without this the /ws/prices route is only a
-      // handshake and subscribers never get a price.
-      await hub.fetch(
-        new Request("http://price-hub/price", {
-          method: "POST",
-          body: JSON.stringify({ tokenAddress: token, price: priceUsd, updatedAt }),
-        }),
-      )
+      // handshake and subscribers never get a price. Only broadcast VALID prices:
+      // fetchTokenPrice returns 0 on lookup failure, and replacing a ticker's last
+      // good value with $0 would be worse than no update at all.
+      if (priceUsd > 0) {
+        await hub.fetch(
+          new Request("http://price-hub/price", {
+            method: "POST",
+            body: JSON.stringify({ tokenAddress: token, price: priceUsd, updatedAt }),
+          }),
+        )
+      }
     } catch (error) {
       console.error(`Failed to refresh price for ${token}:`, error)
     }

--- a/apps/api/test/services/storage-errors.test.ts
+++ b/apps/api/test/services/storage-errors.test.ts
@@ -2,7 +2,13 @@ import { Effect, Layer } from "effect"
 import { SqlClient } from "effect/unstable/sql"
 import { describe, expect, it } from "vitest"
 import { PoolReadError, PoolService, PoolServiceLive } from "../../src/services/pool.service"
-import { TokenListError, TokenReadError, TokenService, TokenServiceLive } from "../../src/services/token.service"
+import {
+  TokenListError,
+  TokenReadError,
+  TokenService,
+  TokenServiceDeps,
+  TokenServiceLive,
+} from "../../src/services/token.service"
 
 const POOL_ID = "0x2222222222222222222222222222222222222222222222222222222222222222"
 const TOKEN_ADDRESS = "0x1111111111111111111111111111111111111111"
@@ -17,6 +23,9 @@ const emptySqlLayer = () => {
   const emptySql = ((..._parts: ReadonlyArray<unknown>) => Effect.succeed([])) as unknown as SqlClient.SqlClient
   return Layer.succeed(SqlClient.SqlClient, emptySql)
 }
+
+const tokenServiceLayer = (sqlLayer: Layer.Layer<SqlClient.SqlClient>) =>
+  TokenServiceLive.pipe(Layer.provide(sqlLayer), Layer.provide(Layer.succeed(TokenServiceDeps, { chainId: 1 })))
 
 describe("PoolService storage failures", () => {
   it("fails getPool with PoolReadError instead of null when D1 rejects a valid id", async () => {
@@ -48,9 +57,7 @@ describe("TokenService storage failures", () => {
       const tokenService = yield* TokenService
       return yield* tokenService.getToken(TOKEN_ADDRESS)
     })
-    const err = await Effect.runPromise(
-      program.pipe(Effect.provide(TokenServiceLive.pipe(Layer.provide(failingSqlLayer()))), Effect.flip),
-    )
+    const err = await Effect.runPromise(program.pipe(Effect.provide(tokenServiceLayer(failingSqlLayer())), Effect.flip))
     expect(err).toBeInstanceOf(TokenReadError)
   })
 
@@ -59,9 +66,7 @@ describe("TokenService storage failures", () => {
       const tokenService = yield* TokenService
       return yield* tokenService.getToken(TOKEN_ADDRESS)
     })
-    const token = await Effect.runPromise(
-      program.pipe(Effect.provide(TokenServiceLive.pipe(Layer.provide(emptySqlLayer())))),
-    )
+    const token = await Effect.runPromise(program.pipe(Effect.provide(tokenServiceLayer(emptySqlLayer()))))
     expect(token).toBeNull()
   })
 
@@ -70,9 +75,7 @@ describe("TokenService storage failures", () => {
       const tokenService = yield* TokenService
       return yield* tokenService.listTokens()
     })
-    const err = await Effect.runPromise(
-      program.pipe(Effect.provide(TokenServiceLive.pipe(Layer.provide(failingSqlLayer()))), Effect.flip),
-    )
+    const err = await Effect.runPromise(program.pipe(Effect.provide(tokenServiceLayer(failingSqlLayer())), Effect.flip))
     expect(err).toBeInstanceOf(TokenListError)
   })
 })

--- a/apps/api/test/services/token-list.test.ts
+++ b/apps/api/test/services/token-list.test.ts
@@ -161,6 +161,18 @@ describe("TokenListService", () => {
     expect(store.size).toBe(1)
   })
 
+  it("stamps timestamps once per refresh — cached reads never fabricate per-request timestamps", async () => {
+    const { kv } = fakeKv()
+    const fetcher = mockFetcherLayer(goodDoc)
+    const layer = serviceLayer(fetcher.layer, kv)
+    const first = await Effect.runPromise(listTokens(layer))
+    const second = await Effect.runPromise(listTokens(layer))
+    // The second read is served from the KV cache: its stamps must equal the refresh
+    // time, not a fresh Date.now() minted at read time.
+    expect(second.map((t) => t.updatedAt)).toEqual(first.map((t) => t.updatedAt))
+    expect(second.every((t) => t.createdAt === t.updatedAt)).toBe(true)
+  })
+
   it("filters by query against symbol/name/address", async () => {
     const { kv } = fakeKv()
     const fetcher = mockFetcherLayer(goodDoc)
@@ -173,10 +185,23 @@ describe("TokenListService", () => {
     expect(tokens.map((t) => t.symbol)).toEqual(["USDC"])
   })
 
+  it("treats a non-finite limit as the default instead of slicing to an empty set", async () => {
+    const { kv } = fakeKv()
+    const fetcher = mockFetcherLayer(goodDoc)
+    const tokens = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TokenListService
+        return yield* svc.listTokens({ limit: Number.NaN })
+      }).pipe(Effect.provide(serviceLayer(fetcher.layer, kv))),
+    )
+    expect(tokens.map((t) => t.symbol).sort()).toEqual(["DAI", "USDC", "WETH"])
+  })
+
   it("falls back to the D1 cache when the fetch fails", async () => {
     const { kv } = fakeKv()
     const d1Rows = [
       {
+        chain_id: 1,
         address: USDC,
         symbol: "USDC",
         name: "USD Coin",
@@ -191,6 +216,7 @@ describe("TokenListService", () => {
     ]
     const tokens = await Effect.runPromise(listTokens(serviceLayer(failingFetcherLayer(), kv, d1Rows)))
     expect(tokens.map((t) => t.symbol)).toEqual(["USDC"])
+    expect(tokens[0]?.chainId).toBe(1)
   })
 
   it("fails the Effect when fetch fails AND both caches are empty", async () => {

--- a/apps/api/test/services/token-list.test.ts
+++ b/apps/api/test/services/token-list.test.ts
@@ -167,8 +167,9 @@ describe("TokenListService", () => {
     const layer = serviceLayer(fetcher.layer, kv)
     const first = await Effect.runPromise(listTokens(layer))
     const second = await Effect.runPromise(listTokens(layer))
-    // The second read is served from the KV cache: its stamps must equal the refresh
-    // time, not a fresh Date.now() minted at read time.
+    // Proof the second read came from the KV cache (and not a same-millisecond re-refresh):
+    expect(fetcher.calls()).toBe(1)
+    // Its stamps must equal the refresh time, not a fresh Date.now() minted at read time.
     expect(second.map((t) => t.updatedAt)).toEqual(first.map((t) => t.updatedAt))
     expect(second.every((t) => t.createdAt === t.updatedAt)).toBe(true)
   })
@@ -188,13 +189,22 @@ describe("TokenListService", () => {
   it("treats a non-finite limit as the default instead of slicing to an empty set", async () => {
     const { kv } = fakeKv()
     const fetcher = mockFetcherLayer(goodDoc)
-    const tokens = await Effect.runPromise(
+    const layer = serviceLayer(fetcher.layer, kv)
+    const nanTokens = await Effect.runPromise(
       Effect.gen(function* () {
         const svc = yield* TokenListService
         return yield* svc.listTokens({ limit: Number.NaN })
-      }).pipe(Effect.provide(serviceLayer(fetcher.layer, kv))),
+      }).pipe(Effect.provide(layer)),
     )
-    expect(tokens.map((t) => t.symbol).sort()).toEqual(["DAI", "USDC", "WETH"])
+    expect(nanTokens.map((t) => t.symbol).sort()).toEqual(["DAI", "USDC", "WETH"])
+    // A negative limit must not become slice(0, -n) (dropping the last entry) either.
+    const negativeTokens = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* TokenListService
+        return yield* svc.listTokens({ limit: -1 })
+      }).pipe(Effect.provide(layer)),
+    )
+    expect(negativeTokens.map((t) => t.symbol).sort()).toEqual(["DAI", "USDC", "WETH"])
   })
 
   it("falls back to the D1 cache when the fetch fails", async () => {

--- a/apps/api/test/ws-routing.test.ts
+++ b/apps/api/test/ws-routing.test.ts
@@ -4,7 +4,7 @@
  * and the DO WebSocket handshake works end-to-end (via SELF, in-process).
  */
 
-import { SELF } from "cloudflare:test"
+import { env, SELF } from "cloudflare:test"
 import { describe, expect, it } from "vitest"
 
 const POOL_ID = "0x2222222222222222222222222222222222222222222222222222222222222222"
@@ -43,14 +43,54 @@ describe("GET /ws/prices/:tokenAddress → WebSocketHubDO", () => {
     if (!ws) return
     ws.accept()
 
+    // Attach each listener BEFORE sending, so a fast response cannot race the handler.
+    const subscribedMessage = nextMessage(ws)
     ws.send(JSON.stringify({ type: "subscribe", poolId: POOL_ID }))
-    const subscribed = (await nextMessage(ws)) as { type: string; data: { poolId: string } }
+    const subscribed = (await subscribedMessage) as { type: string; data: { poolId: string } }
     expect(subscribed.type).toBe("subscribed")
     expect(subscribed.data.poolId).toBe(POOL_ID)
 
+    const pongMessage = nextMessage(ws)
     ws.send(JSON.stringify({ type: "ping" }))
-    const pong = (await nextMessage(ws)) as { type: string }
+    const pong = (await pongMessage) as { type: string }
     expect(pong.type).toBe("pong")
+
+    ws.close(1000, "done")
+  })
+
+  it("fans producer price refreshes out with the per-token payload shape", async () => {
+    const res = await SELF.fetch("http://fake-host/ws/prices/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", {
+      headers: { Upgrade: "websocket" },
+    })
+    const ws = res.webSocket
+    expect(ws).not.toBeNull()
+    if (!ws) return
+    ws.accept()
+
+    const hubNs = env.WEBSOCKET_HUB
+    if (!hubNs) throw new Error("WEBSOCKET_HUB binding is not configured in the test environment")
+    const hub = hubNs.get(hubNs.idFromName("price-hub"))
+    const tokenAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+
+    // The exact envelope the web PriceTicker unwraps. Attach the listener BEFORE
+    // triggering the producer POST, so the broadcast cannot race the handler.
+    const updateMessage = nextMessage(ws)
+    const post = await hub.fetch(
+      new Request("http://price-hub/price", {
+        method: "POST",
+        body: JSON.stringify({ tokenAddress, price: 1.0001, updatedAt: 12345 }),
+      }),
+    )
+    expect(post.status).toBe(200)
+
+    const update = (await updateMessage) as {
+      type: string
+      data: { tokenAddress: string; price: number; updatedAt: number }
+    }
+    expect(update.type).toBe("price_update")
+    expect(update.data.tokenAddress).toBe(tokenAddress)
+    expect(update.data.price).toBe(1.0001)
+    expect(update.data.updatedAt).toBe(12345)
 
     ws.close(1000, "done")
   })
@@ -66,6 +106,32 @@ describe("GET /ws/orderbook/:poolId → OrderBookDO", () => {
     expect(ws).not.toBeNull()
     ws?.accept()
     ws?.close(1000, "done")
+  })
+
+  it("canonicalizes mixed-case pool ids to ONE order book + snapshot key", async () => {
+    // Alphabetic hex spelled two ways: upper- and lower-case refer to the SAME pool.
+    const mixedCase = "0xAbCdEf1234567890aBcDeF1234567890ABCDEF1234567890aBcDeF1234567890"
+    const lowerCase = mixedCase.toLowerCase()
+
+    const connect = async (poolId: string) => {
+      const res = await SELF.fetch(`http://fake-host/ws/orderbook/${poolId}`, {
+        headers: { Upgrade: "websocket" },
+      })
+      expect(res.status).toBe(101)
+      const ws = res.webSocket
+      expect(ws).not.toBeNull()
+      if (!ws) return null
+      ws.accept()
+      const snapshotMessage = nextMessage(ws)
+      const snapshot = (await snapshotMessage) as { type: string; data: { poolId: string } }
+      ws.close(1000, "done")
+      return snapshot
+    }
+
+    const [fromMixed, fromLower] = [await connect(mixedCase), await connect(lowerCase)]
+    // Both casings forward AND persist under the canonical (lower-cased) key.
+    expect(fromMixed?.data.poolId).toBe(lowerCase)
+    expect(fromLower?.data.poolId).toBe(lowerCase)
   })
 
   it("sends an initial orderbook snapshot on connect", async () => {

--- a/apps/web/src/components/PriceTicker.tsx
+++ b/apps/web/src/components/PriceTicker.tsx
@@ -1,12 +1,20 @@
 import { Minus, TrendingDown, TrendingUp } from "lucide-react"
-import { useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useWebSocket } from "../hooks/useWebSocket"
 
-interface PriceData {
+/** One refreshed token price as broadcast by the API's WebSocket hub DO. */
+interface PricePayload {
+  tokenAddress: string
   price: number
+  updatedAt?: number
   change24h?: number
   volume24h?: number
-  pair?: string
+}
+
+/** The hub wraps every frame in an envelope; the payload lives in `data`. */
+interface PriceEnvelope {
+  type: string
+  data?: PricePayload
 }
 
 interface PriceTickerProps {
@@ -45,7 +53,21 @@ export function PriceTicker({
   const defaultWs = `${import.meta.env.VITE_WS_URL ?? "ws://localhost:8080"}/ws/prices/${tokenAddress}?chainId=${chainId}`
   const url = wsUrl ?? defaultWs
 
-  const { data, isConnected, error } = useWebSocket<PriceData>({ url })
+  const { data: envelope, isConnected, error } = useWebSocket<PriceEnvelope>({ url })
+
+  // The hub broadcasts ALL token prices (it is a single shared instance); keep the
+  // latest payload for THIS ticker's token, unwrapped out of the frame envelope.
+  const [data, setData] = useState<PricePayload | null>(null)
+  useEffect(() => {
+    const payload = envelope?.data
+    if (
+      payload &&
+      typeof payload.price === "number" &&
+      payload.tokenAddress.toLowerCase() === tokenAddress.toLowerCase()
+    ) {
+      setData(payload)
+    }
+  }, [envelope, tokenAddress])
 
   const trend = useMemo(() => {
     if (!data?.change24h) return "neutral"

--- a/apps/web/src/components/TokenSearch.tsx
+++ b/apps/web/src/components/TokenSearch.tsx
@@ -99,13 +99,16 @@ export function TokenSearch({ onSelect, selectedToken, placeholder = "Search tok
   }, [])
 
   // Load the default-list top tokens once, when the picker first opens.
+  // Mark "loaded" only after a RETAINED successful response — on failure or on
+  // unmount/cancel the flag stays unset so reopening the picker retries instead of
+  // showing an empty default list for the component's lifetime.
   useEffect(() => {
     if (!isOpen || defaultsLoadedRef.current) return
-    defaultsLoadedRef.current = true
     let cancelled = false
     Effect.runPromise(fetchTokens({ limit: DEFAULT_LIST_LIMIT }))
       .then((res) => {
         if (cancelled) return
+        defaultsLoadedRef.current = true
         setDefaultTokens(res.tokens.map(toToken))
       })
       .catch(() => {

--- a/apps/web/test/components/TokenSearch.test.tsx
+++ b/apps/web/test/components/TokenSearch.test.tsx
@@ -6,6 +6,7 @@ import { TokenSearch } from "../../src/components/TokenSearch"
 // Canonical-list shaped fixtures (what the API serves after validating the
 // Uniswap default token list: schema + EIP-55 checksums + chainId filter).
 const USDC = {
+  chainId: 1,
   address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
   symbol: "USDC",
   name: "USD Coin",
@@ -18,6 +19,7 @@ const USDC = {
   updatedAt: 1719715200,
 }
 const WETH = {
+  chainId: 1,
   address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   symbol: "WETH",
   name: "Wrapped Ether",

--- a/packages/contracts/src/hook/AetherHook.sol
+++ b/packages/contracts/src/hook/AetherHook.sol
@@ -307,7 +307,8 @@ contract AetherHook is IHooks, Ownable {
     /// @notice Time-weighted average tick over the last `secondsAgo` seconds
     /// @param poolId The pool to query
     /// @param secondsAgo Length of the averaging window in seconds (must be > 0)
-    /// @return avgTick The time-weighted average terminal tick (floor division toward zero)
+    /// @return avgTick The time-weighted average terminal tick (rounded toward negative
+    ///         infinity — floor division — so negative, non-divisible deltas round DOWN).
     /// @dev Requires at least two observations, and the window start must lie within the
     ///      retained buffer. Reverts with {Errors.InsufficientObservations} or
     ///      {Errors.InsufficientElapsedTime} otherwise.
@@ -322,7 +323,15 @@ contract AetherHook is IHooks, Ownable {
         // Two's-complement subtraction (overflow-safe for deltas within int56 range),
         // mirroring Uniswap v3's oracle tick averaging.
         unchecked {
-            avgTick = int24((cumulativeNow - cumulativeThen) / int56(uint56(secondsAgo)));
+            int56 numerator = cumulativeNow - cumulativeThen;
+            int56 denominator = int56(uint56(secondsAgo));
+            int56 quotient = numerator / denominator;
+            // Solidity rounds integer division toward zero; for a negative, non-divisible
+            // delta that truncates the average UP by one tick (e.g. -70000/90 = -777 instead
+            // of the floor -778), biasing the TWAP price upward and risking spurious TP/SL
+            // crossings. Decrement the quotient on a negative remainder to floor it.
+            if (numerator < 0 && numerator % denominator != 0) quotient -= int56(1);
+            avgTick = int24(quotient);
         }
     }
 
@@ -498,10 +507,18 @@ contract AetherHook is IHooks, Ownable {
 
         if (!invert) return priceX18;
 
-        // Pair-direction normalization: reciprocal price = 1e18 / priceX18, kept at 1e18 scale.
-        // A zero price (extremely negative tick) has no representable reciprocal at this scale.
-        if (priceX18 == 0) revert Errors.InvalidAmount();
-        return FullMath.mulDiv(1e18, 1e18, priceX18);
+        // Pair-direction normalization: compute the reciprocal at FULL PRECISION directly
+        // from sqrtPriceX96 — NOT as 1/priceX18 of the already-rounded direct quote, which
+        // (a) reverts for negative ticks where priceX18 rounds to zero even though the
+        // reciprocal is perfectly representable, and (b) amplifies one-wei direct-price
+        // rounding into a large quote error when priceX18 is only a few units.
+        //
+        //   inverseX18 = 1e18 / price = Q96^2 * 1e18 / sqrtPriceX96^2
+        //
+        // sqrtPriceX96 is never zero for any tick in TickMath's range (MIN_SQRT_RATIO > 0),
+        // so both divisions below are safe. FullMath handles the 512-bit products.
+        uint256 q96SquaredOverSqrtP = FullMath.mulDiv(FixedPoint96.Q96, FixedPoint96.Q96, uint256(sqrtPriceX96));
+        return FullMath.mulDiv(q96SquaredOverSqrtP, 1e18, uint256(sqrtPriceX96));
     }
 
     /// @notice Modifier to ensure only PoolManager can call hook callbacks

--- a/packages/contracts/test/fuzz/AetherHookInvariants.t.sol
+++ b/packages/contracts/test/fuzz/AetherHookInvariants.t.sol
@@ -40,6 +40,12 @@ contract AetherHookHandler is Test {
     int256 public minTick = type(int256).max;
     int256 public maxTick = type(int256).min;
 
+    // Mirrors the hook's 1024-slot ring so the invariants can clamp queries to the
+    // OLDEST RETAINED observation once the buffer overflows (firstTime stays pinned to
+    // the first-ever swap, which falls out of the ring after 1024 distinct timestamps).
+    uint32[1024] internal _modelTimes;
+    uint16 public modelIndex;
+
     // Handler-owned absolute clock (test-frame block.timestamp can lag cheatcode warps).
     uint32 public clock = 1_000_000_000;
 
@@ -101,11 +107,15 @@ contract AetherHookHandler is Test {
             firstTime = now_;
             expectedCumNow = 0;
             modelObservations = 1;
+            modelIndex = 0;
+            _modelTimes[0] = now_;
         } else if (now_ != lastTime) {
             unchecked {
                 expectedCumNow += int56(int256(lastTick)) * int56(uint56(now_ - lastTime));
             }
             if (modelObservations < 1024) modelObservations += 1;
+            modelIndex = (modelIndex + 1) % 1024;
+            _modelTimes[modelIndex] = now_;
         } // else: identical timestamp → fold in place, cumulative unchanged
         lastTick = tick;
         lastTime = now_;
@@ -124,6 +134,13 @@ contract AetherHookHandler is Test {
 
         vm.prank(address(mockPoolManager));
         hook.afterSwap(address(0xDAD), key, params, delta, "");
+    }
+
+    /// @notice Timestamp of the oldest observation still retained in the model's ring
+    ///         (mirrors the hook's `_oldestIndex` once the 1024-slot buffer overflows).
+    function modelOldestTime() public view returns (uint32) {
+        uint16 count = modelObservations;
+        return _modelTimes[count < 1024 ? 0 : (modelIndex + 1) % 1024];
     }
 
     function _testPoolKey() internal pure returns (PoolKey memory) {
@@ -208,16 +225,23 @@ contract AetherHookInvariantTest is Test {
         );
     }
 
-    /// @notice Over the full recorded history, the TWAP tick stays within [min, max] observed
+    /// @notice Over the RETAINED observation history, the TWAP tick stays within the
+    ///         [min, max] observed across all history (the retained window is a subset,
+    ///         so its average cannot leave the overall bounds).
+    /// @dev The window is clamped to the oldest RETAINED observation (`modelOldestTime`),
+    ///      not the first-ever swap: once the 1024-slot ring overflows, `firstTime` falls
+    ///      out of the buffer and `getTwapTick` would (correctly) revert with
+    ///      InsufficientElapsedTime — failing the invariant on buffer overflow rather
+    ///      than on TWAP correctness.
     function invariant_twapTick_withinObservedRange() public view {
         if (handler.modelObservations() < 2) return;
 
-        uint32 first = handler.firstTime();
+        uint32 oldestRetained = handler.modelOldestTime();
         uint32 last = handler.lastTime();
-        if (last <= first) return;
+        if (last <= oldestRetained) return;
 
-        // Window [first, now]: the view call's frame sees the correctly warped "now".
-        uint32 window = last - first;
+        // Window [oldestRetained, now]: the view call's frame sees the correctly warped "now".
+        uint32 window = last - oldestRetained;
         int256 avg = int256(hook.getTwapTick(handler.poolId(), window));
         assertGe(avg, handler.minTick(), "TWAP tick must be >= min observed tick");
         assertLe(avg, handler.maxTick(), "TWAP tick must be <= max observed tick");

--- a/packages/contracts/test/unit/AetherHook.t.sol
+++ b/packages/contracts/test/unit/AetherHook.t.sol
@@ -439,7 +439,7 @@ contract AetherHookTest is Test {
         //   t=t0+30  : swap -> tick -2000 recorded, cum = 1000*30            =    30_000
         //   t=t0+90  : swap -> tick  3000 recorded, cum = 30_000 + (-2000)*60 =   -90_000
         //   [now]    : +10 more seconds at tick 3000 (extrapolated), cum now  =   -60_000
-        // Window = 100s (full, t=t0): avgTick = (-60_000 - 0) / 100 = -600 (floor toward zero)
+        // Window = 100s (full, t=t0): avgTick = (-60_000 - 0) / 100 = -600 (exact)
         _setTick(1000);
         _doSwap(true, 1e9, 1e9); // t0
 
@@ -463,9 +463,10 @@ contract AetherHookTest is Test {
         // Sub-window [now-90, now] spans the -2000 and +3000 spans only:
         //   cum(now)    = -60_000
         //   cum(now-90) = interp at t0+10: 0 + 1000*10 = 10_000
-        //   avg = (-60_000 - 10_000) / 90 = -777
+        //   avg = (-60_000 - 10_000) / 90 = -70_000/90 -> floor = -778
+        //   (truncation toward zero would give the biased -777).
         int24 avgSub = hook.getTwapTick(poolId, 90);
-        assertEq(avgSub, -777, "exact time-weighted tick over a sub-window");
+        assertEq(avgSub, -778, "negative avg tick must round DOWN (floor), not toward zero");
 
         // Price conversion is deterministic from the avg tick.
         uint256 price = hook.getCurrentTwap(poolId, 100);
@@ -647,8 +648,13 @@ contract AetherHookTest is Test {
         _advance(uint256(hold1));
 
         uint32 window = hold0 + hold1;
-        int256 expected =
-            (int256(tick0) * int256(uint256(hold0)) + int256(tick1) * int256(uint256(hold1))) / int256(uint256(window));
+        int256 numerator =
+            int256(tick0) * int256(uint256(hold0)) + int256(tick1) * int256(uint256(hold1));
+        int256 denom = int256(uint256(window));
+        // The hook floors negative averages (rounds toward negative infinity); mirror it here
+        // instead of Solidity's default truncation toward zero.
+        int256 expected = numerator / denom;
+        if (numerator < 0 && numerator % denom != 0) expected -= 1;
 
         int24 avgTick = hook.getTwapTick(poolId, window);
         assertEq(int256(avgTick), expected, "TWAP tick must be elapsed-time weighted");

--- a/packages/contracts/test/unit/AetherHookTwap.t.sol
+++ b/packages/contracts/test/unit/AetherHookTwap.t.sol
@@ -58,7 +58,7 @@ contract AetherHookTwapTest is Test {
 
     /// @notice Schedule: tick -500 held 100s, then +1500 held 200s, then +200 held 50s.
     ///         Any window must equal the elapsed-time-weighted tick average, computed here
-    ///         independently and asserted exactly (integer division, floor toward zero).
+    ///         independently and asserted exactly (integer division, floored).
     function test_twap_exactKnownSequence_allWindows() public {
         _swapAtTick(-500); // obs0 @ t=0: cum 0
         _advance(100);
@@ -85,7 +85,7 @@ contract AetherHookTwapTest is Test {
 
         // Price at the full-window avg tick, exactly.
         assertEq(hook.getCurrentTwap(poolId, 350), _priceX18AtTick(742), "price(twap tick)");
-        assertEq(hook.getCurrentTwapInverted(poolId, 350), _invertPrice(_priceX18AtTick(742)), "reciprocal price");
+        assertEq(hook.getCurrentTwapInverted(poolId, 350), _invertPriceX18AtTick(742), "reciprocal price");
     }
 
     /// @notice Cross-tick sequence from the plan's example: +6000 for 30s then -6000 for 70s.
@@ -107,9 +107,9 @@ contract AetherHookTwapTest is Test {
         assertGt(twapPrice, _priceX18AtTick(-6000), "twap > low spot");
     }
 
-    /// @notice Time-weighting must dominate sample-counting: 1 sample at tick 0 held 99s +
-    ///         99 samples at tick 1000 held 1s each → TWAP(198s) ≈ 502, not ~990
-    ///         (sample-count average) nor 0. This is the bug G2.5 fixes.
+    /// @notice Time-weighting must dominate sample-counting: tick 0 held 1s, then 99 samples
+    ///         at tick 1000 spanning 99s → TWAP(100s) = 990 by elapsed time. The discriminating
+    ///         check is the [now-1, now] window (pure tick 1000). This is the bug G2.5 fixes.
     function test_twap_timeWeightsNotSampleCounts() public {
         _swapAtTick(0); // t=0
         for (uint256 i = 0; i < 99; i++) {
@@ -148,7 +148,7 @@ contract AetherHookTwapTest is Test {
         uint256 inverted = hook.getCurrentTwapInverted(poolId, 120);
 
         assertEq(direct, _priceX18AtTick(6000), "direct = spot price in token1/token0");
-        assertEq(inverted, _invertPrice(direct), "inverted = 1e18-scaled reciprocal");
+        assertEq(inverted, _invertPriceX18AtTick(6000), "inverted = full-precision 1e18-scaled reciprocal");
 
         // Round-trip product ≈ 1e36 within integer flooring (< 0.01% error).
         assertApproxEqRel(FullMath.mulDiv(direct, inverted, 1e18), 1e18, 1e14, "p * (1/p) ~= 1");
@@ -178,17 +178,22 @@ contract AetherHookTwapTest is Test {
         assertApproxEqRel(FullMath.mulDiv(direct, inverted, 1e18), 1e18, 1e14, "reciprocal identity");
     }
 
-    function test_twap_invertedZeroPrice_reverts() public {
-        // tick -460_517 -> price ~1e-20, which floors to 0 at 1e18 scale: the reciprocal
-        // read must reject it rather than divide by zero.
+    function test_twap_invertedReadable_evenWhenDirectFloorsToZero() public {
+        // tick -460_517 -> price ~1e-20, which floors to 0 at 1e18 scale. The reciprocal
+        // (~1e38 at this scale) IS representable, so a full-precision inverse computed
+        // directly from sqrtPriceX96 must return an accurate value instead of reverting
+        // on the already-rounded direct quote (which is exactly what keepers read in the
+        // reverse direction).
         _swapAtTick(-460_517);
         _advance(20);
         _swapAtTick(-460_517);
         _advance(20);
 
         assertEq(hook.getCurrentTwap(poolId, 40), 0, "direct price floors to zero at this tick");
-        vm.expectRevert(Errors.InvalidAmount.selector);
-        hook.getCurrentTwapInverted(poolId, 40);
+
+        uint256 inverted = hook.getCurrentTwapInverted(poolId, 40);
+        assertGt(inverted, 0, "reverse read stays representable when the direct quote rounds to zero");
+        assertEq(inverted, _invertPriceX18AtTick(-460_517), "full-precision reciprocal of the TWAP tick");
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -352,7 +357,11 @@ contract AetherHookTwapTest is Test {
         uint32 window = da + db + dc;
         int256 weighted =
             int256(a) * int256(uint256(da)) + int256(b) * int256(uint256(db)) + int256(c) * int256(uint256(dc));
-        int256 expectedTick = weighted / int256(uint256(window));
+        // The hook floors negative averages (rounds toward negative infinity) rather than
+        // truncating toward zero — mirror that here.
+        int256 denom = int256(uint256(window));
+        int256 expectedTick = weighted / denom;
+        if (weighted < 0 && weighted % denom != 0) expectedTick -= 1;
 
         int24 actual = hook.getTwapTick(poolId, window);
         assertEq(int256(actual), expectedTick, "exact elapsed-time weighting over 3 spans");
@@ -360,9 +369,8 @@ contract AetherHookTwapTest is Test {
         // Price must be the deterministic conversion of that exact tick.
         assertEq(hook.getCurrentTwap(poolId, window), _priceX18AtTick(actual), "price(tick) identity");
 
-        // Reciprocal read must be the exact 1e18-scaled reciprocal of the direct price.
-        uint256 direct = hook.getCurrentTwap(poolId, window);
-        assertEq(hook.getCurrentTwapInverted(poolId, window), _invertPrice(direct), "reciprocal identity");
+        // Reciprocal read must be the exact full-precision 1e18-scaled reciprocal of the tick.
+        assertEq(hook.getCurrentTwapInverted(poolId, window), _invertPriceX18AtTick(actual), "reciprocal identity");
     }
 
     function testFuzz_twapTickWithinObservedRange(int24 a, int24 b, uint32 da, uint32 db) public {
@@ -417,8 +425,13 @@ contract AetherHookTwapTest is Test {
         return FullMath.mulDiv(priceX96, 1e18, FixedPoint96.Q96);
     }
 
-    function _invertPrice(uint256 priceX18) internal pure returns (uint256) {
-        return FullMath.mulDiv(1e18, 1e18, priceX18);
+    /// @dev The exact 1e18-scaled reciprocal of `price(tick)`, computed at full precision
+    ///      directly from sqrtPriceX96: `Q96^2 * 1e18 / sqrtPriceX96^2` (mirrors the hook —
+    ///      NOT the naive 1e36/round(priceX18), which rounds away precision).
+    function _invertPriceX18AtTick(int24 tick) internal pure returns (uint256) {
+        uint256 p = uint256(TickMath.getSqrtPriceAtTick(tick));
+        uint256 q96SquaredOverSqrtP = FullMath.mulDiv(FixedPoint96.Q96, FixedPoint96.Q96, p);
+        return FullMath.mulDiv(q96SquaredOverSqrtP, 1e18, p);
     }
 
     /// @dev Advance time by `dt` seconds using the test-owned absolute clock.
@@ -447,9 +460,13 @@ contract AetherHookTwapTest is Test {
     }
 
     /// @dev The hook's TWAP over `window` must equal the trace-independent average
-    ///      `(cumNow - cumStart) / window`.
+    ///      `(cumNow - cumStart) / window`, floored toward negative infinity (the hook no
+    ///      longer truncates negative divisions toward zero).
     function _assertWindow(uint32 window, int256 cumNow, int256 cumStart, string memory label) internal view {
-        int256 expected = (cumNow - cumStart) / int256(uint256(window));
+        int256 numerator = cumNow - cumStart;
+        int256 denom = int256(uint256(window));
+        int256 expected = numerator / denom;
+        if (numerator < 0 && numerator % denom != 0) expected -= 1;
         assertEq(int256(hook.getTwapTick(poolId, window)), expected, label);
     }
 }

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -40,6 +40,7 @@ export type PoolListResponse = Schema.Schema.Type<typeof PoolListResponseSchema>
  * chainId filter) before serving.
  */
 export const TokenSchema = Schema.Struct({
+  chainId: Schema.Number,
   address: Schema.String,
   symbol: Schema.String,
   name: Schema.String,


### PR DESCRIPTION
Follow-up PR addressing the review findings on the merged **PR #306** (G2.5 TWAP oracle) and **PR #307** (Phase-0 apps G1–G4).

## #306 contracts
| Finding | Fix |
|---|---|
| P2 — negative TWAP avg ticks truncated toward zero (AetherHook.sol:325) | Floor division toward −∞ in `getTwapTick` (e.g. -70000/90 → -778); tests updated to floor expectations incl. the -778 vector |
| P2 — inverted quote computed from the rounded direct price (AetherHook.sol:504) | Full-precision reciprocal `Q96²·1e18/sqrtP²` straight from `sqrtPriceX96`; representable + accurate even when the direct price floors to zero (test rewritten accordingly) |
| Docstring contradicts test body (AetherHookTwap.t.sol:135) | NatSpec aligned with the implemented schedule |
| Invariant window vs ring overflow (AetherHookInvariants.t.sol:224) | Handler tracks the oldest *retained* observation; invariant clamps the window to it |

## #307 apps
| Finding | Fix |
|---|---|
| Non-numeric `limit` → empty result | NaN guard in route (+ defensive `Number.isFinite` clamp in the service) |
| 🟠 Major — token cache/schema not chain-scoped | Migration 0003: tokens PK `(chain_id, address)`; chain_id in INSERT/ON CONFLICT; `WHERE chain_id` on D1 fallback + cron refresh; `TokenSchema.chainId` |
| Fabricated timestamps on every cached read | `asOf` stamped once per refresh, stored in the KV envelope, reused on reads (regression test added) |
| ws-routing listener ordering (ws-routing.test.ts:52) | Promises created before sends |
| Token address validation (chain-state-reader.ts:130) | `isAddress` + `getAddress` before `Token`; constructor failures map to `OnChainReadError("invalid_pool_key")` |
| P1 — tick probes not aligned to tick-spacing (chain-state-reader.ts:177) | Scan anchored to boundaries (`floor(tick/spacing)·spacing ± k·spacing`, anchor included) |
| P1 — legacy fallback on any V4 error (swap.service.ts:312) | Rollback only when the reader reports `not_configured`; authoritative failures propagate |
| P1 — prices never published to the WS hub (index.ts:129) | Price-refresh queue publishes `POST /price` after each KV write |
| P2 — price WS payload mismatched its consumer (index.ts:129) | Per-token `{tokenAddress, price, updatedAt}` envelope; PriceTicker unwraps + filters by token (no `undefined.toFixed` crash) |
| P2 — quotes leaving the scanned tick window (swap.ts:65) | `verifiedTickWindow` in state; engine rejects out-of-window simulations (`price_out_of_range`) |
| P2 — default token list never retries (TokenSearch.tsx:104) | `loaded` flag set only on retained success |
| Canonicalize poolId casing (index.ts:141) | `toLowerCase()` before DO selection + forwarded key (+ regression test) |
| Dependency pins (package.json) | `jsbi@3`/`ethers@5` documented as explicit test-pool exceptions in apps/api/README.md |

## Verification (all exit 0)
- contracts: `forge build`, `forge test` — 134 passing
- root: `bun run typecheck`, `bun run lint`, `bun run test` — 88 passing
- api: `typecheck`, `test` — 44 passing, `build` (wrangler dry-run)
- web: `build`, `typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token data, caching, and search are now chain-scoped for more reliable multi-network support.
  * Live price streaming is now delivered per token (token-address subscriptions).
  * Verified-tick-window constraints can cause quotes to reject out-of-range prices.

* **Bug Fixes**
  * Improved `limit` parsing to prevent NaN/negative pagination issues.
  * Canonicalized pool IDs so mixed-case and lowercase map to the same orderbook snapshot.
  * Safer quote/swap error handling now includes “price out of range”.

* **Documentation**
  * Added notes documenting intentional dependency version exceptions.

* **Tests**
  * Updated/added coverage for token caching, WebSocket updates, and TWAP edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->