### PR TITLE
fix: secure phase 1 rebalance funding

### DIFF
--- a/apps/api/src/routes/positions.ts
+++ b/apps/api/src/routes/positions.ts
@@ -66,7 +66,7 @@ positions.get("/users/:address/positions", async (c) => {
  * POST /api/v1/positions
  * Record a new LP position (requires auth — user records their own position)
  */
-positions.post("/", requireAuth, async (c) => {
+positions.post("/positions", requireAuth, async (c) => {
   const session = c.get("session")
   if (!session) return c.json({ error: "Unauthorized" }, 401)
 

--- a/apps/api/test/positions-reconcile.test.ts
+++ b/apps/api/test/positions-reconcile.test.ts
@@ -105,3 +105,16 @@ describe("POST /api/v1/positions/v4/:tokenId/reconcile", () => {
     await expect(response.json()).resolves.toEqual({ error: "Authentication required" })
   })
 })
+
+describe("POST /api/v1/positions", () => {
+  it("routes position creation through the authenticated endpoint", async () => {
+    const response = await SELF.fetch("http://fake-host/api/v1/positions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    })
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: "Authentication required" })
+  })
+})

--- a/packages/contracts/src/interfaces/IAetherPositionManager.sol
+++ b/packages/contracts/src/interfaces/IAetherPositionManager.sol
@@ -14,6 +14,7 @@ interface IAetherPositionManager {
     error NativeTransferFailed();
     error UnexpectedNativeValue();
     error InsufficientCallBalance();
+    error RebalanceOwnerOnly();
 
     struct MintPositionParams {
         PoolKey poolKey;

--- a/packages/contracts/src/position/AetherPositionManager.sol
+++ b/packages/contracts/src/position/AetherPositionManager.sol
@@ -153,9 +153,7 @@ contract AetherPositionManager is IAetherPositionManager, IUnlockCallback, ERC72
         if (params.liquidity == 0) revert InvalidLiquidity();
         if (params.tickLower >= params.tickUpper) revert InvalidLiquidity();
         address positionOwner = _ownerOf(params.tokenId);
-        if (!_isAuthorized(positionOwner, msg.sender, params.tokenId)) {
-            _checkAuthorized(positionOwner, msg.sender, params.tokenId);
-        }
+        if (msg.sender != positionOwner) revert RebalanceOwnerOnly();
         Position memory position = _positions[params.tokenId];
         if (
             !position.poolKey.currency0.isAddressZero() && !position.poolKey.currency1.isAddressZero() && msg.value != 0

--- a/packages/contracts/test/unit/AetherPositionManager.t.sol
+++ b/packages/contracts/test/unit/AetherPositionManager.t.sol
@@ -226,8 +226,18 @@ contract AetherPositionManagerTest is Test {
     function test_rebalancePosition_revertsForUnapprovedCaller() public {
         uint256 tokenId = _mintForUser();
 
-        vm.expectRevert(abi.encodeWithSelector(IERC721Errors.ERC721InsufficientApproval.selector, attacker, tokenId));
+        vm.expectRevert(IAetherPositionManager.RebalanceOwnerOnly.selector);
         vm.prank(attacker);
+        positionManager.rebalancePosition(_rebalanceParams(tokenId));
+    }
+
+    function test_rebalancePosition_revertsForApprovedOperator() public {
+        uint256 tokenId = _mintForUser();
+        vm.prank(user);
+        positionManager.approve(operator, tokenId);
+
+        vm.expectRevert(IAetherPositionManager.RebalanceOwnerOnly.selector);
+        vm.prank(operator);
         positionManager.rebalancePosition(_rebalanceParams(tokenId));
     }
 


### PR DESCRIPTION
Follow-up security fix after Phase 1 merge.\n\n- restrict V4 rebalance to the position owner so approved NFT operators cannot charge owner ERC20 allowances\n- fix the authenticated position-create route used by the primary V4 zap\n- add regression coverage for approved operators and the HTTP route\n\nVerified locally with 17/17 AetherPositionManager tests and the API positions route test.

## Summary by Sourcery

Restrict V4 position rebalancing to position owners and align the positions API creation route with the authenticated endpoint.

Bug Fixes:
- Limit V4 position rebalancing so only the NFT owner can execute it, preventing approved operators from using the owner's ERC20 allowances.
- Route position creation through the authenticated positions endpoint to enforce proper session-based authorization.

Tests:
- Add regression tests ensuring rebalance reverts for both unapproved callers and approved NFT operators.
- Add API test verifying the positions creation endpoint requires authentication and returns the expected error response when unauthenticated.