### PR TITLE
ci: make Codecov uploads non-fatal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always()
+        continue-on-error: true # Codecov is optional; protected-branch PRs may lack a token.
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: packages/contracts/lcov.info
@@ -302,6 +303,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always()
+        continue-on-error: true # Codecov is optional; protected-branch PRs may lack a token.
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: apps/api/coverage/lcov.info
@@ -346,6 +348,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always()
+        continue-on-error: true # Codecov is optional; protected-branch PRs may lack a token.
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: apps/web/coverage/lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+# Codecov uploads are non-gating; enforced coverage steps remain mandatory.
 
 on:
   push:


### PR DESCRIPTION
Codecov uploads failed on protected-branch PRs with 'Token required because branch is protected', which failed the Contracts job even though enforced Foundry coverage passed. Mark the optional uploads as continue-on-error; enforced coverage gates remain unchanged.

## Summary by Sourcery

CI:
- Allow Codecov upload steps to fail without breaking CI while keeping enforced coverage checks unchanged.