### PR TITLE
feat(api): keeper funded signer/relayer + MEV Tier-B submission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ packages/contracts/broadcast/
 # Cloudflare
 .cloudflare/
 
+# Alchemy IaC local state/bundles (infra/alchemy deploys)
+.alchemy/
+
 # Environment
 .env
 .env.local

--- a/apps/api/migrations/0008_tp_sl_onchain_order_id.sql
+++ b/apps/api/migrations/0008_tp_sl_onchain_order_id.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tp_sl_orders ADD COLUMN onchain_order_id TEXT;
+
+CREATE INDEX idx_tp_sl_orders_chain_onchain_id
+  ON tp_sl_orders(chain_id, onchain_order_id);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -50,6 +50,16 @@ type Bindings = {
   AETHER_HOOK_ADDRESS?: string
   V3_EXECUTOR_ADDRESS?: string
   TREASURY_ADDRESS?: string
+  // Phase 2/3 keeper relayer — secrets (KEEPER_PRIVATE_KEY, KEEPER_RPC_URL) via
+  // `wrangler secret put`; non-secret knobs default to evaluation-only in
+  // src/lib/keeper-signer.ts.
+  TPSL_ADDRESS?: string
+  AETHER_TPSL_ADDRESS?: string
+  KEEPER_RPC_URL?: string
+  KEEPER_MAX_GAS_PRICE_GWEI?: string
+  KEEPER_MIN_BALANCE_ETH?: string
+  KEEPER_ALLOW_PUBLIC_SUBMISSION?: string
+  KEEPER_PRIVATE_KEY?: string
   // Phase-3 API safety knobs — optional; safe defaults live in src/lib/safety-config.ts.
   RATE_LIMIT_MAX?: string
   RATE_LIMIT_WINDOW_SECONDS?: string
@@ -246,9 +256,15 @@ const worker = {
       WEBSOCKET_HUB: env.WEBSOCKET_HUB,
       CHAIN_ID: env.CHAIN_ID,
       RPC_URL: env.RPC_URL,
-      // Phase 4 (#314): keeper queue needs the AetherHook oracle for on-chain TP/SL TWAP reads
-      // (queue-handler.readTwapFromChain). Undefined is safe — it falls back to KV-cached prices.
       AETHER_HOOK_ADDRESS: env.AETHER_HOOK_ADDRESS,
+      TPSL_ADDRESS: env.TPSL_ADDRESS,
+      AETHER_TPSL_ADDRESS: env.AETHER_TPSL_ADDRESS,
+      KEEPER_PRIVATE_KEY: env.KEEPER_PRIVATE_KEY,
+      KEEPER_RPC_URL: env.KEEPER_RPC_URL,
+      KEEPER_MAX_GAS_PRICE_GWEI: env.KEEPER_MAX_GAS_PRICE_GWEI,
+      KEEPER_MIN_BALANCE_ETH: env.KEEPER_MIN_BALANCE_ETH,
+      KEEPER_ALLOW_PUBLIC_SUBMISSION: env.KEEPER_ALLOW_PUBLIC_SUBMISSION,
+      PRIVATE_TX_RELAY_URL: env.PRIVATE_TX_RELAY_URL,
       INDEXER_ENABLED: env.INDEXER_ENABLED,
       INDEXER_BATCH_SIZE: env.INDEXER_BATCH_SIZE,
       V3_POSITION_MANAGER_ADDRESS: env.V3_POSITION_MANAGER_ADDRESS,

--- a/apps/api/src/lib/keeper-signer.ts
+++ b/apps/api/src/lib/keeper-signer.ts
@@ -1,0 +1,503 @@
+/**
+ * AetherDEX Keeper Relayer — Phase 2/3 (MEV Tier-B private submission)
+ *
+ * Funds + signs keeper transactions for unattended TP/SL (auto-recenter later)
+ * execution. Safe-by-default submission policy:
+ *
+ *   1. PRIVATE_TX_RELAY_URL set (https only)  → sign locally, POST the signed
+ *      raw tx to the relay via eth_sendRawTransaction (MEV Tier-B: protected,
+ *      private submission — never broadcast to the public mempool).
+ *   2. else KEEPER_ALLOW_PUBLIC_SUBMISSION="true" → explicit opt-in public send
+ *      via the wallet client.
+ *   3. otherwise → "submission-disabled": the keeper stays EVALUATION-ONLY and
+ *      no transaction is built or sent.
+ *
+ * Security: the private key (KEEPER_PRIVATE_KEY secret) is loaded into a viem
+ * account and NEVER logged; signed raw transactions are never logged either.
+ * All env reads are defensive — malformed values degrade to the safe default.
+ */
+
+import {
+  createPublicClient,
+  createWalletClient,
+  encodeFunctionData,
+  http,
+  isAddress,
+  parseAbi,
+  parseEther,
+  parseGwei,
+} from "viem"
+import { privateKeyToAccount } from "viem/accounts"
+import { parseChainId } from "./chain-id"
+import { parsePositiveFloat } from "./safety-config"
+
+// ─── Env + config ───────────────────────────────────────────────────────────
+
+/** Keeper-related env vars. All optional — missing/malformed values keep the
+ *  relayer evaluation-only (safe default). Secrets are set via
+ *  `wrangler secret put` (KEEPER_PRIVATE_KEY, KEEPER_RPC_URL). */
+export interface KeeperSignerEnv {
+  readonly CHAIN_ID?: string
+  readonly KEEPER_PRIVATE_KEY?: string
+  readonly KEEPER_RPC_URL?: string
+  readonly KEEPER_MAX_GAS_PRICE_GWEI?: string
+  readonly KEEPER_MIN_BALANCE_ETH?: string
+  readonly KEEPER_ALLOW_PUBLIC_SUBMISSION?: string
+  readonly PRIVATE_TX_RELAY_URL?: string
+  readonly TPSL_ADDRESS?: string
+  readonly AETHER_TPSL_ADDRESS?: string
+}
+
+export interface KeeperSignerConfig {
+  /** Chain the keeper operates on; null keeps the relayer evaluation-only. */
+  readonly chainId: number | null
+  /** Normalized 0x-prefixed 32-byte hex key, or null when absent/invalid. */
+  readonly privateKey: `0x${string}` | null
+  /** RPC endpoint transactions are sent through (signing always happens locally). */
+  readonly rpcUrl: string | null
+  /** Optional gas price ceiling in gwei; null = no ceiling. */
+  readonly maxGasPriceGwei: number | null
+  /** Gas-funding budget guard (default 0.05 ETH). */
+  readonly minBalanceWei: bigint
+  /** https-only relay endpoint; null when unset or non-https. */
+  readonly privateRelayUrl: string | null
+  /** Public-mempool opt-in. Defaults to false (never on by default). */
+  readonly allowPublicSubmission: boolean
+  /** Resolved AetherTPSL contract address, or null. */
+  readonly tpslAddress: `0x${string}` | null
+}
+
+export const DEFAULT_MIN_BALANCE_ETH = "0.05"
+
+const parseHexPrivateKey = (raw: string | undefined): `0x${string}` | null => {
+  if (raw === undefined) return null
+  const trimmed = raw.trim()
+  const candidate = trimmed.startsWith("0x") ? trimmed.slice(2) : trimmed
+  return /^[0-9a-fA-F]{64}$/.test(candidate) ? `0x${candidate.toLowerCase()}` : null
+}
+
+/** Only https relays are accepted — private submission over cleartext is never allowed. */
+export const parseRelayUrl = (raw: string | undefined): string | null => {
+  if (raw === undefined) return null
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return null
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    return null
+  }
+  return parsed.protocol === "https:" ? trimmed : null
+}
+
+const parseAddress = (raw: string | undefined): `0x${string}` | null => {
+  if (raw === undefined) return null
+  const trimmed = raw.trim()
+  return isAddress(trimmed) ? (trimmed as `0x${string}`) : null
+}
+
+const isFlagEnabled = (raw: string | undefined): boolean => raw?.trim().toLowerCase() === "true"
+
+const parseMinBalanceWei = (raw: string | undefined): bigint => {
+  if (parsePositiveFloat(raw) === undefined) return parseEther(DEFAULT_MIN_BALANCE_ETH)
+  try {
+    return parseEther((raw as string).trim())
+  } catch {
+    return parseEther(DEFAULT_MIN_BALANCE_ETH)
+  }
+}
+
+/** Resolves the AetherTPSL address (TPSL_ADDRESS wins, then AETHER_TPSL_ADDRESS). */
+export const resolveTpslAddress = (env: KeeperSignerEnv): `0x${string}` | null =>
+  parseAddress(env.TPSL_ADDRESS) ?? parseAddress(env.AETHER_TPSL_ADDRESS)
+
+export function readKeeperSignerConfig(env: KeeperSignerEnv): KeeperSignerConfig {
+  return {
+    chainId: parseChainId(env.CHAIN_ID),
+    privateKey: parseHexPrivateKey(env.KEEPER_PRIVATE_KEY),
+    rpcUrl: env.KEEPER_RPC_URL?.trim() ? env.KEEPER_RPC_URL.trim() : null,
+    maxGasPriceGwei: parsePositiveFloat(env.KEEPER_MAX_GAS_PRICE_GWEI) ?? null,
+    minBalanceWei: parseMinBalanceWei(env.KEEPER_MIN_BALANCE_ETH),
+    privateRelayUrl: parseRelayUrl(env.PRIVATE_TX_RELAY_URL),
+    allowPublicSubmission: isFlagEnabled(env.KEEPER_ALLOW_PUBLIC_SUBMISSION),
+    tpslAddress: resolveTpslAddress(env),
+  }
+}
+
+// ─── Typed errors ───────────────────────────────────────────────────────────
+
+/** Transient RPC failure (balance/nonce/gas reads or public submission). Safe to retry. */
+export class KeeperRpcError extends Error {
+  readonly _tag = "KeeperRpcError"
+}
+
+/** Keeper wallet cannot fund the gas budget. Deterministic — retrying immediately is pointless. */
+export class InsufficientKeeperBalanceError extends Error {
+  readonly _tag = "InsufficientKeeperBalanceError"
+  constructor(
+    readonly address: string,
+    readonly balanceWei: bigint,
+    readonly minimumWei: bigint,
+  ) {
+    super(`Keeper balance ${balanceWei} wei is below the ${minimumWei} wei funding floor`)
+  }
+}
+
+/** Current gas price exceeds the configured ceiling. Deterministic while the ceiling holds. */
+export class GasPriceExceededError extends Error {
+  readonly _tag = "GasPriceExceededError"
+  constructor(
+    readonly gasPriceWei: bigint,
+    readonly maxGasPriceWei: bigint,
+  ) {
+    super(`Gas price ${gasPriceWei} wei exceeds the ${maxGasPriceWei} wei ceiling`)
+  }
+}
+
+/** Requested chain does not match the keeper's configured chain. Deterministic misconfiguration. */
+export class KeeperChainMismatchError extends Error {
+  readonly _tag = "KeeperChainMismatchError"
+  constructor(
+    readonly expectedChainId: number,
+    readonly actualChainId: number,
+    readonly address: string,
+  ) {
+    super(`Keeper is configured for chain ${expectedChainId} but received chain ${actualChainId}`)
+  }
+}
+
+/** Private relay rejection or transport failure. `retryable` marks 5xx / network faults. */
+export class KeeperRelayError extends Error {
+  readonly _tag = "KeeperRelayError"
+  constructor(
+    message: string,
+    readonly retryable: boolean,
+  ) {
+    super(message)
+  }
+}
+
+/** True for errors where a queue retry can plausibly succeed (network/RPC/5xx). */
+export const isTransientKeeperError = (error: unknown): boolean => {
+  if (error instanceof KeeperRpcError) return true
+  if (error instanceof KeeperRelayError) return error.retryable
+  return false
+}
+
+// ─── Submission types ───────────────────────────────────────────────────────
+
+export type SubmissionChannel = "private-relay" | "public" | "evaluation-only"
+
+export type SubmissionResult =
+  | { readonly kind: "submitted"; readonly channel: SubmissionChannel; readonly txHash: `0x${string}` }
+  | { readonly kind: "submission-disabled"; readonly reason: string }
+
+export interface SendTransactionInput {
+  readonly to: `0x${string}`
+  readonly data: `0x${string}`
+  readonly value?: bigint
+  /** Must match the keeper's configured chainId when both are set. */
+  readonly chainId?: number
+  /** Optional gas limit override (otherwise estimated via the RPC). */
+  readonly gasLimit?: bigint
+}
+
+export interface KeeperSigner {
+  /** Signing address, or null when no key/RPC is configured. */
+  readonly address: `0x${string}` | null
+  /** Which channel this signer will use; "evaluation-only" never submits. */
+  readonly channel: SubmissionChannel
+  sendTransaction(input: SendTransactionInput): Promise<SubmissionResult>
+}
+
+/** Minimal surface of the viem public client the relayer drives (test seam). */
+interface KeeperChainClient {
+  getBalance(args: { address: `0x${string}` }): Promise<bigint>
+  getTransactionCount(args: { address: `0x${string}` }): Promise<number>
+  estimateGas(args: {
+    account: { address: `0x${string}` }
+    to: `0x${string}`
+    data: `0x${string}`
+    value?: bigint
+  }): Promise<bigint>
+  getGasPrice(): Promise<bigint>
+}
+
+// Minimal viem wallet surface. account is deliberately NOT a per-call arg: a
+// non-LocalAccount value would silently reroute the send to a JSON-RPC
+// "unlocked account" instead of local signing — a keeper security footgun.
+interface KeeperSubmitClient {
+  sendTransaction(args: {
+    chain: null
+    to: `0x${string}`
+    data: `0x${string}`
+    value?: bigint
+    nonce: number
+    gas: bigint
+    gasPrice: bigint
+  }): Promise<`0x${string}`>
+}
+
+export interface KeeperSignerDeps {
+  readonly publicClient?: KeeperChainClient
+  readonly walletClient?: KeeperSubmitClient
+  readonly fetchFn?: typeof fetch
+}
+
+// ─── AetherTPSL encoding ────────────────────────────────────────────────────
+
+export const AETHER_TPSL_ABI = parseAbi([
+  "function executeOrder(uint256 orderId, bytes hookData) returns (bool executed)",
+])
+
+/**
+ * Encode an AetherTPSL.executeOrder calldata payload. hookData defaults to "0x":
+ * AetherTPSL.executeOrder re-verifies the dual trigger on-chain from the order's
+ * own stored parameters before moving funds, so no hook payload is required.
+ */
+export function encodeExecuteOrder(orderId: number | bigint, hookData: `0x${string}` = "0x"): `0x${string}` {
+  const id = BigInt(orderId)
+  if (id < 0n) throw new RangeError(`orderId must be non-negative, got ${orderId}`)
+  return encodeFunctionData({ abi: AETHER_TPSL_ABI, functionName: "executeOrder", args: [id, hookData] })
+}
+
+// ─── Authorization policy helpers (pure) ────────────────────────────────────
+
+export interface TpSlExecutableLike {
+  readonly status: string
+  /** Epoch milliseconds, matching tp_sl_orders.deadline. */
+  readonly deadline: number
+  readonly chainId: number
+  readonly amountIn?: string
+}
+
+export interface TpSlExecutionPolicy {
+  readonly expectedChainId: number
+  /** Optional cap on the input amount the keeper is allowed to execute. */
+  readonly maxAmountIn?: bigint
+}
+
+/**
+ * Pure pre-execution authorization gate: status must be pending, the deadline
+ * must be in the future, the order's chain must match, and — when the policy
+ * carries a cap — the input amount must not exceed it.
+ */
+export function canExecuteTpSlOrder(
+  order: TpSlExecutableLike,
+  policy: TpSlExecutionPolicy,
+  now: number,
+): boolean {
+  if (order.status !== "pending") return false
+  if (!Number.isFinite(order.deadline) || !Number.isFinite(now) || order.deadline <= now) return false
+  if (!Number.isInteger(order.chainId) || !Number.isInteger(policy.expectedChainId)) return false
+  if (order.chainId !== policy.expectedChainId) return false
+  if (policy.maxAmountIn !== undefined) {
+    let amountIn: bigint
+    try {
+      amountIn = BigInt(order.amountIn ?? "")
+    } catch {
+      return false
+    }
+    if (amountIn > policy.maxAmountIn) return false
+  }
+  return true
+}
+
+export interface RecenterPolicyLike {
+  readonly isActive: boolean | number
+}
+
+/** Pure authorization gate for auto-recenter: only active policies may execute. */
+export function canExecuteRecenter(policy: RecenterPolicyLike): boolean {
+  return policy.isActive === true || policy.isActive === 1
+}
+
+// ─── Signer factory ─────────────────────────────────────────────────────────
+
+const TX_HASH_PATTERN = /^0x[0-9a-fA-F]{64}$/
+
+export function createKeeperSigner(config: KeeperSignerConfig, deps: KeeperSignerDeps = {}): KeeperSigner {
+  const fetchImpl = deps.fetchFn ?? fetch
+
+  const disabled = (address: `0x${string}` | null, reason: string): KeeperSigner => ({
+    address,
+    channel: "evaluation-only",
+    sendTransaction: () => Promise.resolve({ kind: "submission-disabled", reason }),
+  })
+
+  if (config.privateKey === null) {
+    return disabled(null, "KEEPER_PRIVATE_KEY not configured — evaluation-only")
+  }
+  if (config.rpcUrl === null) {
+    return disabled(null, "KEEPER_RPC_URL not configured — evaluation-only")
+  }
+  if (config.chainId === null) {
+    return disabled(null, "CHAIN_ID not configured — cannot sign chain-scoped transactions")
+  }
+
+  const account = privateKeyToAccount(config.privateKey)
+  const chainId = config.chainId
+
+  if (config.privateRelayUrl === null && !config.allowPublicSubmission) {
+    return disabled(
+      account.address,
+      "No PRIVATE_TX_RELAY_URL configured and KEEPER_ALLOW_PUBLIC_SUBMISSION is not 'true' — safe evaluation-only default",
+    )
+  }
+
+  const transport = http(config.rpcUrl)
+  const publicClient: KeeperChainClient = (deps.publicClient ?? createPublicClient({ transport })) as KeeperChainClient
+
+  const preflight = async (
+    input: SendTransactionInput,
+  ): Promise<{ nonce: number; gas: bigint; gasPrice: bigint }> => {
+    if (input.chainId !== undefined && input.chainId !== chainId) {
+      throw new KeeperChainMismatchError(chainId, input.chainId, account.address)
+    }
+    let nonce: number
+    let balance: bigint
+    let gas: bigint
+    let gasPrice: bigint
+    try {
+      nonce = await publicClient.getTransactionCount({ address: account.address })
+      balance = await publicClient.getBalance({ address: account.address })
+      gasPrice = await publicClient.getGasPrice()
+      gas =
+        input.gasLimit ??
+        (await publicClient.estimateGas({
+          account: { address: account.address },
+          to: input.to,
+          data: input.data,
+          ...(input.value !== undefined ? { value: input.value } : {}),
+        }))
+    } catch (error) {
+      if (error instanceof KeeperChainMismatchError) throw error
+      throw new KeeperRpcError(`Keeper preflight RPC failed: ${String(error)}`)
+    }
+    if (balance < config.minBalanceWei) {
+      throw new InsufficientKeeperBalanceError(account.address, balance, config.minBalanceWei)
+    }
+    if (config.maxGasPriceGwei !== null) {
+      const ceiling = parseGwei(String(config.maxGasPriceGwei))
+      if (gasPrice > ceiling) throw new GasPriceExceededError(gasPrice, ceiling)
+    }
+    return { nonce, gas, gasPrice }
+  }
+
+  if (config.privateRelayUrl !== null) {
+    const relayUrl = config.privateRelayUrl
+    return {
+      address: account.address,
+      channel: "private-relay",
+      sendTransaction: async (input: SendTransactionInput): Promise<SubmissionResult> => {
+        const { nonce, gas, gasPrice } = await preflight(input)
+
+        let signed: `0x${string}`
+        try {
+          signed = await account.signTransaction({
+            chainId,
+            to: input.to,
+            data: input.data,
+            ...(input.value !== undefined ? { value: input.value } : {}),
+            nonce,
+            gas,
+            gasPrice,
+          })
+        } catch (error) {
+          throw new KeeperRpcError(`Keeper tx signing failed: ${String(error)}`)
+        }
+
+        // Defense in depth: parseRelayUrl already enforces https at config time.
+        let relay: URL
+        try {
+          relay = new URL(relayUrl)
+        } catch {
+          throw new KeeperRelayError("PRIVATE_TX_RELAY_URL is invalid", false)
+        }
+        if (relay.protocol !== "https:") {
+          throw new KeeperRelayError("PRIVATE_TX_RELAY_URL must use https (MEV Tier-B)", false)
+        }
+
+        let response: Response
+        try {
+          response = await fetchImpl(relayUrl, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            // NOTE: the signed raw tx is deliberately never logged.
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "eth_sendRawTransaction",
+              params: [signed],
+            }),
+          })
+        } catch (error) {
+          throw new KeeperRelayError(`Private relay request failed: ${String(error)}`, true)
+        }
+
+        if (!response.ok) {
+          throw new KeeperRelayError(
+            `Private relay returned HTTP ${response.status}`,
+            response.status >= 500,
+          )
+        }
+
+        let payload: Record<string, unknown> | null = null
+        try {
+          const body: unknown = await response.json()
+          if (typeof body === "object" && body !== null) payload = body as Record<string, unknown>
+        } catch {
+          payload = null
+        }
+        if (payload === null) throw new KeeperRelayError("Private relay returned a non-JSON response", false)
+
+        const errorField = payload.error
+        if (errorField !== undefined && errorField !== null) {
+          const message =
+            typeof errorField === "object"
+              ? String((errorField as { message?: unknown }).message ?? "rejected")
+              : String(errorField)
+          throw new KeeperRelayError(`Private relay rejected transaction: ${message}`, false)
+        }
+
+        if (typeof payload.result !== "string" || !TX_HASH_PATTERN.test(payload.result)) {
+          throw new KeeperRelayError("Private relay response is missing a valid transaction hash", false)
+        }
+
+        return { kind: "submitted", channel: "private-relay", txHash: payload.result as `0x${string}` }
+      },
+    }
+  }
+
+  // Explicit public-submission opt-in.
+  const walletClient: KeeperSubmitClient = (deps.walletClient ??
+    createWalletClient({
+      account,
+      transport,
+    })) as unknown as KeeperSubmitClient
+
+  return {
+    address: account.address,
+    channel: "public",
+    sendTransaction: async (input: SendTransactionInput): Promise<SubmissionResult> => {
+      const { nonce, gas, gasPrice } = await preflight(input)
+      let txHash: `0x${string}`
+      try {
+        txHash = await walletClient.sendTransaction({
+          // chain: null → send on the wallet client's default chain; the target
+          // chain was already validated against the config in preflight.
+          chain: null,
+          to: input.to,
+          data: input.data,
+          ...(input.value !== undefined ? { value: input.value } : {}),
+          nonce,
+          gas,
+          gasPrice,
+        })
+      } catch (error) {
+        throw new KeeperRpcError(`Public submission failed: ${String(error)}`)
+      }
+      return { kind: "submitted", channel: "public", txHash }
+    },
+  }
+}

--- a/apps/api/src/lib/keeper-signer.ts
+++ b/apps/api/src/lib/keeper-signer.ts
@@ -23,9 +23,11 @@ import {
   encodeFunctionData,
   http,
   isAddress,
+  keccak256,
   parseAbi,
   parseEther,
   parseGwei,
+  toBytes,
 } from "viem"
 import { privateKeyToAccount } from "viem/accounts"
 import { parseChainId } from "./chain-id"
@@ -177,6 +179,13 @@ export class KeeperRelayError extends Error {
   }
 }
 
+export class KeeperTransactionError extends Error {
+  readonly _tag = "KeeperTransactionError"
+  constructor(readonly txHash: string, message: string) {
+    super(message)
+  }
+}
+
 /** True for errors where a queue retry can plausibly succeed (network/RPC/5xx). */
 export const isTransientKeeperError = (error: unknown): boolean => {
   if (error instanceof KeeperRpcError) return true
@@ -189,7 +198,12 @@ export const isTransientKeeperError = (error: unknown): boolean => {
 export type SubmissionChannel = "private-relay" | "public" | "evaluation-only"
 
 export type SubmissionResult =
-  | { readonly kind: "submitted"; readonly channel: SubmissionChannel; readonly txHash: `0x${string}` }
+  | {
+      readonly kind: "submitted"
+      readonly channel: SubmissionChannel
+      readonly txHash: `0x${string}`
+      readonly confirmed?: boolean
+    }
   | { readonly kind: "submission-disabled"; readonly reason: string }
 
 export interface SendTransactionInput {
@@ -213,7 +227,7 @@ export interface KeeperSigner {
 /** Minimal surface of the viem public client the relayer drives (test seam). */
 interface KeeperChainClient {
   getBalance(args: { address: `0x${string}` }): Promise<bigint>
-  getTransactionCount(args: { address: `0x${string}` }): Promise<number>
+  getTransactionCount(args: { address: `0x${string}`; blockTag?: "pending" }): Promise<number>
   estimateGas(args: {
     account: { address: `0x${string}` }
     to: `0x${string}`
@@ -221,6 +235,12 @@ interface KeeperChainClient {
     value?: bigint
   }): Promise<bigint>
   getGasPrice(): Promise<bigint>
+  waitForTransactionReceipt?(args: { hash: `0x${string}` }): Promise<KeeperTransactionReceipt>
+}
+
+interface KeeperTransactionReceipt {
+  readonly status: "success" | "reverted"
+  readonly logs: readonly { readonly address: string; readonly topics: readonly string[] }[]
 }
 
 // Minimal viem wallet surface. account is deliberately NOT a per-call arg: a
@@ -244,6 +264,8 @@ export interface KeeperSignerDeps {
   readonly fetchFn?: typeof fetch
 }
 
+const ORDER_EXECUTED_TOPIC = keccak256(toBytes("OrderExecuted(uint256,address,uint256,uint256)"))
+
 // ─── AetherTPSL encoding ────────────────────────────────────────────────────
 
 export const AETHER_TPSL_ABI = parseAbi([
@@ -255,7 +277,7 @@ export const AETHER_TPSL_ABI = parseAbi([
  * AetherTPSL.executeOrder re-verifies the dual trigger on-chain from the order's
  * own stored parameters before moving funds, so no hook payload is required.
  */
-export function encodeExecuteOrder(orderId: number | bigint, hookData: `0x${string}` = "0x"): `0x${string}` {
+export function encodeExecuteOrder(orderId: string | number | bigint, hookData: `0x${string}` = "0x"): `0x${string}` {
   const id = BigInt(orderId)
   if (id < 0n) throw new RangeError(`orderId must be non-negative, got ${orderId}`)
   return encodeFunctionData({ abi: AETHER_TPSL_ABI, functionName: "executeOrder", args: [id, hookData] })
@@ -347,6 +369,40 @@ export function createKeeperSigner(config: KeeperSignerConfig, deps: KeeperSigne
 
   const transport = http(config.rpcUrl)
   const publicClient: KeeperChainClient = (deps.publicClient ?? createPublicClient({ transport })) as KeeperChainClient
+  let nextNonce: number | undefined
+  let submissionTail = Promise.resolve()
+
+  const withSubmissionLock = async <T>(operation: () => Promise<T>): Promise<T> => {
+    const previous = submissionTail
+    let release: (() => void) | undefined
+    submissionTail = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    await previous
+    try {
+      return await operation()
+    } finally {
+      release?.()
+    }
+  }
+
+  const awaitConfirmation = async (txHash: `0x${string}`, target: `0x${string}`): Promise<boolean | undefined> => {
+    if (publicClient.waitForTransactionReceipt === undefined) return undefined
+    let receipt: KeeperTransactionReceipt
+    try {
+      receipt = await publicClient.waitForTransactionReceipt({ hash: txHash })
+    } catch (error) {
+      throw new KeeperRpcError(`Keeper receipt wait failed: ${String(error)}`)
+    }
+    if (receipt.status === "reverted") {
+      throw new KeeperTransactionError(txHash, "Keeper transaction reverted")
+    }
+    return receipt.logs.some(
+      (log) =>
+        log.address.toLowerCase() === target.toLowerCase() &&
+        log.topics[0]?.toLowerCase() === ORDER_EXECUTED_TOPIC.toLowerCase(),
+    )
+  }
 
   const preflight = async (
     input: SendTransactionInput,
@@ -359,7 +415,8 @@ export function createKeeperSigner(config: KeeperSignerConfig, deps: KeeperSigne
     let gas: bigint
     let gasPrice: bigint
     try {
-      nonce = await publicClient.getTransactionCount({ address: account.address })
+      const pendingNonce = await publicClient.getTransactionCount({ address: account.address, blockTag: "pending" })
+      nonce = Math.max(pendingNonce, nextNonce ?? pendingNonce)
       balance = await publicClient.getBalance({ address: account.address })
       gasPrice = await publicClient.getGasPrice()
       gas =
@@ -389,8 +446,9 @@ export function createKeeperSigner(config: KeeperSignerConfig, deps: KeeperSigne
     return {
       address: account.address,
       channel: "private-relay",
-      sendTransaction: async (input: SendTransactionInput): Promise<SubmissionResult> => {
-        const { nonce, gas, gasPrice } = await preflight(input)
+      sendTransaction: async (input: SendTransactionInput): Promise<SubmissionResult> =>
+        withSubmissionLock(async () => {
+          const { nonce, gas, gasPrice } = await preflight(input)
 
         let signed: `0x${string}`
         try {
@@ -464,8 +522,13 @@ export function createKeeperSigner(config: KeeperSignerConfig, deps: KeeperSigne
           throw new KeeperRelayError("Private relay response is missing a valid transaction hash", false)
         }
 
-        return { kind: "submitted", channel: "private-relay", txHash: payload.result as `0x${string}` }
-      },
+          const txHash = payload.result as `0x${string}`
+          nextNonce = nonce + 1
+          const confirmed = await awaitConfirmation(txHash, input.to)
+          return confirmed === undefined
+            ? { kind: "submitted", channel: "private-relay", txHash }
+            : { kind: "submitted", channel: "private-relay", txHash, confirmed }
+        }),
     }
   }
 
@@ -479,8 +542,9 @@ export function createKeeperSigner(config: KeeperSignerConfig, deps: KeeperSigne
   return {
     address: account.address,
     channel: "public",
-    sendTransaction: async (input: SendTransactionInput): Promise<SubmissionResult> => {
-      const { nonce, gas, gasPrice } = await preflight(input)
+    sendTransaction: async (input: SendTransactionInput): Promise<SubmissionResult> =>
+      withSubmissionLock(async () => {
+        const { nonce, gas, gasPrice } = await preflight(input)
       let txHash: `0x${string}`
       try {
         txHash = await walletClient.sendTransaction({
@@ -497,7 +561,11 @@ export function createKeeperSigner(config: KeeperSignerConfig, deps: KeeperSigne
       } catch (error) {
         throw new KeeperRpcError(`Public submission failed: ${String(error)}`)
       }
-      return { kind: "submitted", channel: "public", txHash }
-    },
+        nextNonce = nonce + 1
+        const confirmed = await awaitConfirmation(txHash, input.to)
+        return confirmed === undefined
+          ? { kind: "submitted", channel: "public", txHash }
+          : { kind: "submitted", channel: "public", txHash, confirmed }
+      }),
   }
 }

--- a/apps/api/src/routes/tp-sl.ts
+++ b/apps/api/src/routes/tp-sl.ts
@@ -48,6 +48,7 @@ tpSl.post("/orders", requireAuth, async (c) => {
     twapWindow?: number
     slippageBps?: number
     deadline?: number
+    onchainOrderId?: string
   }>()
 
   if (
@@ -59,12 +60,13 @@ tpSl.post("/orders", requireAuth, async (c) => {
     !body.triggerPriceX18 ||
     !body.twapWindow ||
     body.slippageBps === undefined ||
-    !body.deadline
+    !body.deadline ||
+    !body.onchainOrderId
   ) {
     return c.json(
       {
         error:
-          "poolId, orderType, zeroForOne, amountIn, minAmountOut, triggerPriceX18, twapWindow, slippageBps, deadline required",
+          "poolId, orderType, zeroForOne, amountIn, minAmountOut, triggerPriceX18, twapWindow, slippageBps, deadline, onchainOrderId required",
       },
       400,
     )
@@ -83,7 +85,8 @@ tpSl.post("/orders", requireAuth, async (c) => {
     body.slippageBps < 0 ||
     !Number.isFinite(body.deadline) ||
     !Number.isInteger(body.deadline) ||
-    body.deadline <= Date.now()
+    body.deadline <= Date.now() ||
+    !uintPattern.test(body.onchainOrderId)
   ) {
     return c.json({ error: "Invalid TP/SL order values" }, 400)
   }
@@ -101,8 +104,18 @@ tpSl.post("/orders", requireAuth, async (c) => {
   }
 
   // At this point all fields are validated as present
-  const { poolId, orderType, zeroForOne, amountIn, minAmountOut, triggerPriceX18, twapWindow, slippageBps, deadline } =
-    body
+  const {
+    poolId,
+    orderType,
+    zeroForOne,
+    amountIn,
+    minAmountOut,
+    triggerPriceX18,
+    twapWindow,
+    slippageBps,
+    deadline,
+    onchainOrderId,
+  } = body
 
   try {
     const program = Effect.gen(function* () {
@@ -118,6 +131,7 @@ tpSl.post("/orders", requireAuth, async (c) => {
         twapWindow,
         slippageBps,
         deadline,
+        onchainOrderId,
         chainId: chainIdFor(c),
       })
     })

--- a/apps/api/src/services/tp-sl.service.ts
+++ b/apps/api/src/services/tp-sl.service.ts
@@ -15,6 +15,7 @@ export type OrderStatus = "pending" | "triggered" | "executed" | "cancelled" | "
 
 export interface TpSlOrder {
   readonly id: number
+  readonly onchainOrderId: string | null
   readonly userAddress: string
   readonly poolId: string
   readonly orderType: OrderType
@@ -44,6 +45,7 @@ export interface CreateOrderInput {
   readonly twapWindow: number
   readonly slippageBps: number
   readonly deadline: number
+  readonly onchainOrderId: string
   readonly chainId?: number
 }
 
@@ -137,6 +139,7 @@ export const TpSlService = Context.Service<TpSlService>("@aetherdex/TpSlService"
 function rowToOrder(row: Record<string, unknown>): TpSlOrder {
   return {
     id: row.id as number,
+    onchainOrderId: (row.onchain_order_id as string | null) ?? null,
     userAddress: row.user_address as string,
     poolId: row.pool_id as string,
     orderType: row.order_type as OrderType,
@@ -169,10 +172,10 @@ const makeTpSlService = Effect.gen(function* () {
       const rows = (yield* sql`
         INSERT INTO tp_sl_orders
           (user_address, pool_id, order_type, zero_for_one, amount_in, min_amount_out,
-           trigger_price_x18, twap_window, slippage_bps, deadline, status, created_at, chain_id)
+           trigger_price_x18, twap_window, slippage_bps, deadline, status, created_at, chain_id, onchain_order_id)
         VALUES (${input.userAddress}, ${input.poolId}, ${input.orderType}, ${input.zeroForOne ? 1 : 0},
                 ${input.amountIn}, ${input.minAmountOut}, ${input.triggerPriceX18}, ${input.twapWindow},
-                ${input.slippageBps}, ${input.deadline}, 'pending', ${now}, ${chainId})
+                ${input.slippageBps}, ${input.deadline}, 'pending', ${now}, ${chainId}, ${input.onchainOrderId})
         RETURNING id
       `) as unknown as readonly Record<string, unknown>[]
 

--- a/apps/api/src/workers/cron-handler.ts
+++ b/apps/api/src/workers/cron-handler.ts
@@ -180,7 +180,7 @@ async function runKeeperTick(env: CronEnv): Promise<void> {
   console.log(`[Keeper] Tick started for chain ${chainId}`)
 
   const pendingOrders = await env.DB.prepare(`
-    SELECT id, pool_id, order_type, zero_for_one, amount_in, min_amount_out,
+    SELECT id, onchain_order_id, pool_id, order_type, zero_for_one, amount_in, min_amount_out,
            trigger_price_x18, twap_window, slippage_bps, deadline, user_address
     FROM tp_sl_orders
     WHERE chain_id = ? AND status = 'pending' AND deadline > ?
@@ -190,6 +190,7 @@ async function runKeeperTick(env: CronEnv): Promise<void> {
     .bind(chainId, now)
     .all<{
       id: number
+      onchain_order_id: string | null
       pool_id: string
       order_type: string
       zero_for_one: number
@@ -211,9 +212,14 @@ async function runKeeperTick(env: CronEnv): Promise<void> {
 
   for (const order of pendingOrders.results) {
     try {
+      if (typeof order.onchain_order_id !== "string" || !/^[0-9]+$/.test(order.onchain_order_id)) {
+        console.warn(`[Keeper] Order ${order.id} has no valid on-chain order ID, skipping enqueue`)
+        continue
+      }
       await env.KEEPER_QUEUE.send({
         type: "tp-sl-evaluate",
         orderId: order.id,
+        onchainOrderId: order.onchain_order_id,
         poolId: order.pool_id,
         orderType: order.order_type,
         zeroForOne: Boolean(order.zero_for_one),

--- a/apps/api/src/workers/queue-handler.ts
+++ b/apps/api/src/workers/queue-handler.ts
@@ -10,7 +10,18 @@
 import { Effect, Layer } from "effect"
 import { createPublicClient, http, type PublicClient } from "viem"
 import { makeDbLayer } from "../db/client"
+import { parseChainId } from "../lib/chain-id"
 import { runEffect } from "../lib/effect-bridge"
+import {
+  canExecuteTpSlOrder,
+  createKeeperSigner,
+  encodeExecuteOrder,
+  isTransientKeeperError,
+  type KeeperSigner,
+  readKeeperSignerConfig,
+  resolveTpslAddress,
+  type SubmissionResult,
+} from "../lib/keeper-signer"
 import { IndexerService, IndexerServiceLive, type IndexerSource } from "../services/indexer.service"
 import { buildIndexerChainConfig, isIndexerEnabled } from "./indexer-config"
 
@@ -100,7 +111,24 @@ export interface QueueEnv {
   V3_POSITION_MANAGER_ADDRESS?: string
   V3_INDEXED_POOL_ADDRESSES?: string
   V4_POOL_MANAGER_ADDRESS?: string
+  // Phase 2/3 keeper relayer — secrets (KEEPER_PRIVATE_KEY, KEEPER_RPC_URL) via
+  // `wrangler secret put`; the rest are non-secret knobs parsed with safe
+  // defaults in src/lib/keeper-signer.ts. Absent config = evaluation-only.
+  TPSL_ADDRESS?: string
+  AETHER_TPSL_ADDRESS?: string
+  KEEPER_PRIVATE_KEY?: string
+  KEEPER_RPC_URL?: string
+  KEEPER_MAX_GAS_PRICE_GWEI?: string
+  KEEPER_MIN_BALANCE_ETH?: string
+  KEEPER_ALLOW_PUBLIC_SUBMISSION?: string
+  PRIVATE_TX_RELAY_URL?: string
 }
+
+/**
+ * Test seam for the keeper relayer. Production omits it for the env-derived
+ * viem signer; tests inject a fake to verify execution orchestration offline.
+ */
+export type KeeperSignerFactory = (env: QueueEnv) => KeeperSigner
 
 const INDEXER_SOURCES: readonly IndexerSource[] = ["v3_position_manager", "v3_pool", "v4_pool_manager"]
 
@@ -155,12 +183,14 @@ async function readTwapFromChain(
 
 /**
  * Process a batch of queue messages. `clientFactory` is a test seam forwarded
- * to the indexer backfill handler; production omits it for the default viem client.
+ * to the indexer backfill handler; `signerFactory` is a test seam for the
+ * keeper relayer. Production omits both for the default viem clients.
  */
 export const processQueueBatch = async (
   batch: MessageBatch<unknown>,
   env: QueueEnv,
   clientFactory?: (rpcUrl: string) => PublicClient,
+  signerFactory?: KeeperSignerFactory,
 ): Promise<void> => {
   console.log(`Processing ${batch.messages.length} queue messages`)
 
@@ -178,7 +208,7 @@ export const processQueueBatch = async (
           await handleTradeArchive(msg, env)
           break
         case "tp-sl-evaluate":
-          await handleTpSlEvaluate(msg, env)
+          await handleTpSlEvaluate(msg, env, signerFactory)
           break
         case "auto-recenter-check":
           await handleAutoRecenterCheck(msg, env)
@@ -256,7 +286,11 @@ async function handleIndexerBackfill(
 
 // ─── TP/SL Evaluation Handler ───────────────────────────────────────────────
 
-async function handleTpSlEvaluate(msg: TpSlEvaluateMessage, env: QueueEnv): Promise<void> {
+async function handleTpSlEvaluate(
+  msg: TpSlEvaluateMessage,
+  env: QueueEnv,
+  signerFactory?: KeeperSignerFactory,
+): Promise<void> {
   console.log(`[Keeper] Evaluating TP/SL order ${msg.orderId} for pool ${msg.poolId}`)
 
   // 1. Verify order is still pending
@@ -354,31 +388,94 @@ async function handleTpSlEvaluate(msg: TpSlEvaluateMessage, env: QueueEnv): Prom
     return
   }
 
-  // 6. Trigger is breached — mark for execution
-  console.log(`[Keeper] Order ${msg.orderId} trigger BREACHED — marking for execution`)
+  // 6. Trigger is breached — run the authorization gate before spending gas.
+  const expectedChainId = parseChainId(env.CHAIN_ID)
+  if (expectedChainId === null) {
+    console.warn(`[Keeper] CHAIN_ID '${env.CHAIN_ID}' is invalid — cannot authorize execution, keeping order pending`)
+    return
+  }
 
-  // Update order status to 'triggered' and enqueue for on-chain execution
-  await env.DB.prepare(`
-    UPDATE tp_sl_orders
-    SET status = 'triggered', updated_at = ?
-    WHERE id = ? AND chain_id = ? AND status = 'pending'
-  `)
-    .bind(Date.now(), msg.orderId, msg.chainId)
+  const executionContext = {
+    orderId: msg.orderId,
+    poolId: msg.poolId,
+    orderType: msg.orderType,
+    chainId: msg.chainId,
+    userAddress: msg.userAddress,
+    amountIn: msg.amountIn,
+  }
+
+  if (
+    !canExecuteTpSlOrder(
+      { status: order.status, deadline: msg.deadline, chainId: msg.chainId, amountIn: msg.amountIn },
+      { expectedChainId },
+      Date.now(),
+    )
+  ) {
+    console.log(
+      JSON.stringify({
+        event: "tp_sl_execution_unauthorized",
+        ...executionContext,
+        reason: "authorization gate rejected (status, deadline, or chain mismatch)",
+      }),
+    )
+    return
+  }
+
+  const tpslAddress = resolveTpslAddress(env)
+  if (tpslAddress === null) {
+    console.warn("[Keeper] TPSL_ADDRESS not configured — TP/SL execution stays evaluation-only, keeping order pending")
+    return
+  }
+
+  console.log(`[Keeper] Order ${msg.orderId} trigger BREACHED — submitting execution`)
+
+  // 7. Submit the on-chain execution via the keeper relayer. The AetherTPSL
+  // contract re-verifies the dual trigger itself before moving funds, so a
+  // duplicate submission at worst reverts on-chain — never double-executes.
+  const signer = signerFactory !== undefined ? signerFactory(env) : createKeeperSigner(readKeeperSignerConfig(env))
+  let submission: SubmissionResult
+  try {
+    submission = await signer.sendTransaction({
+      to: tpslAddress,
+      data: encodeExecuteOrder(msg.orderId),
+      chainId: msg.chainId,
+    })
+  } catch (error) {
+    // Transient failures (RPC / relay 5xx) re-throw so the queue retries;
+    // deterministic failures are logged and the order stays pending.
+    if (isTransientKeeperError(error)) throw error
+    console.error(
+      JSON.stringify({
+        event: "tp_sl_execution_failed",
+        ...executionContext,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    )
+    return
+  }
+
+  if (submission.kind === "submission-disabled") {
+    console.log(JSON.stringify({ event: "tp_sl_submission_disabled", ...executionContext, reason: submission.reason }))
+    return
+  }
+
+  // Submitted — mark triggered + record the tx hash. On-chain reconciliation
+  // (verification service / indexer) advances the order to 'executed' later.
+  await env.DB.prepare(
+    "UPDATE tp_sl_orders SET status = 'triggered', execution_tx_hash = ?, updated_at = ? WHERE id = ? AND chain_id = ? AND status = 'pending'",
+  )
+    .bind(submission.txHash, Date.now(), msg.orderId, msg.chainId)
     .run()
 
-  // In production, this would also submit the transaction via the keeper's funded signer
-  // For now, log the execution intent
   console.log(
     JSON.stringify({
       event: "tp_sl_triggered",
-      orderId: msg.orderId,
-      poolId: msg.poolId,
-      orderType: msg.orderType,
-      spotPriceX18: spotPriceX18,
+      ...executionContext,
+      txHash: submission.txHash,
+      channel: submission.channel,
+      spotPriceX18,
       twapPriceX18,
       triggerPriceX18: msg.triggerPriceX18,
-      userAddress: msg.userAddress,
-      amountIn: msg.amountIn,
     }),
   )
 }

--- a/apps/api/src/workers/queue-handler.ts
+++ b/apps/api/src/workers/queue-handler.ts
@@ -57,6 +57,7 @@ export interface TradeArchiveMessage {
 export interface TpSlEvaluateMessage {
   type: "tp-sl-evaluate"
   orderId: number
+  onchainOrderId: string
   poolId: string
   orderType: string
   zeroForOne: boolean
@@ -295,10 +296,10 @@ async function handleTpSlEvaluate(
 
   // 1. Verify order is still pending
   const order = await env.DB.prepare(
-    "SELECT id, status, deadline FROM tp_sl_orders WHERE id = ? AND chain_id = ? AND status = 'pending'",
+    "SELECT id, onchain_order_id, status, deadline FROM tp_sl_orders WHERE id = ? AND chain_id = ? AND status = 'pending'",
   )
     .bind(msg.orderId, msg.chainId)
-    .first<{ id: number; status: string; deadline: number }>()
+    .first<{ id: number; onchain_order_id: string | null; status: string; deadline: number }>()
 
   if (!order) {
     console.log(`[Keeper] Order ${msg.orderId} no longer pending, skipping`)
@@ -311,6 +312,11 @@ async function handleTpSlEvaluate(
       .bind(msg.orderId, msg.chainId)
       .run()
     console.log(`[Keeper] Order ${msg.orderId} expired`)
+    return
+  }
+
+  if (typeof order.onchain_order_id !== "string" || !/^[0-9]+$/.test(order.onchain_order_id)) {
+    console.warn(`[Keeper] Order ${msg.orderId} has no valid on-chain order ID, skipping submission`)
     return
   }
 
@@ -437,7 +443,7 @@ async function handleTpSlEvaluate(
   try {
     submission = await signer.sendTransaction({
       to: tpslAddress,
-      data: encodeExecuteOrder(msg.orderId),
+      data: encodeExecuteOrder(order.onchain_order_id),
       chainId: msg.chainId,
     })
   } catch (error) {
@@ -459,12 +465,23 @@ async function handleTpSlEvaluate(
     return
   }
 
-  // Submitted — mark triggered + record the tx hash. On-chain reconciliation
-  // (verification service / indexer) advances the order to 'executed' later.
+  if (submission.confirmed !== true) {
+    await env.DB.prepare(
+      "UPDATE tp_sl_orders SET execution_tx_hash = ?, updated_at = ? WHERE id = ? AND chain_id = ? AND status = 'pending'",
+    )
+      .bind(submission.txHash, Date.now(), msg.orderId, msg.chainId)
+      .run()
+    console.log(
+      JSON.stringify({ event: "tp_sl_execution_unconfirmed", ...executionContext, txHash: submission.txHash }),
+    )
+    return
+  }
+
+  const confirmedAt = Date.now()
   await env.DB.prepare(
-    "UPDATE tp_sl_orders SET status = 'triggered', execution_tx_hash = ?, updated_at = ? WHERE id = ? AND chain_id = ? AND status = 'pending'",
+    "UPDATE tp_sl_orders SET status = 'executed', execution_tx_hash = ?, executed_at = ?, updated_at = ? WHERE id = ? AND chain_id = ? AND status = 'pending'",
   )
-    .bind(submission.txHash, Date.now(), msg.orderId, msg.chainId)
+    .bind(submission.txHash, confirmedAt, confirmedAt, msg.orderId, msg.chainId)
     .run()
 
   console.log(

--- a/apps/api/test/keeper-signer.test.ts
+++ b/apps/api/test/keeper-signer.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Keeper relayer (src/lib/keeper-signer.ts) — offline unit tests:
+ * config parsing with safe defaults, authorization policy helpers, MEV Tier-B
+ * private-relay submission via mocked fetch, explicit public opt-in, and the
+ * balance / gas / chain preflight guards. No network access.
+ */
+
+import { parseEther, parseGwei, toFunctionSelector } from "viem"
+import { describe, expect, it, vi } from "vitest"
+import {
+  canExecuteRecenter,
+  canExecuteTpSlOrder,
+  createKeeperSigner,
+  encodeExecuteOrder,
+  GasPriceExceededError,
+  InsufficientKeeperBalanceError,
+  isTransientKeeperError,
+  KeeperChainMismatchError,
+  KeeperRelayError,
+  KeeperRpcError,
+  type KeeperSignerEnv,
+  parseRelayUrl,
+  readKeeperSignerConfig,
+  resolveTpslAddress,
+} from "../src/lib/keeper-signer"
+
+const TEST_PRIVATE_KEY = `0x${"11".repeat(32)}`
+const TEST_ADDRESS = "0x19E7E376E7C213B7E7e7e46cc70A5dD086DAff2A"
+const RELAY_URL = "https://relay.example/submit"
+const TX_HASH = `0x${"ab".repeat(32)}`
+
+const baseEnv: KeeperSignerEnv = {
+  CHAIN_ID: "11155111",
+  KEEPER_PRIVATE_KEY: TEST_PRIVATE_KEY,
+  KEEPER_RPC_URL: "https://rpc.example/v1",
+}
+
+const makeChainStub = (overrides: Record<string, unknown> = {}) => ({
+  getBalance: async () => parseEther("1"),
+  getTransactionCount: async () => 7,
+  estimateGas: async () => 120_000n,
+  getGasPrice: async () => parseGwei("2"),
+  ...overrides,
+})
+
+const makeRelaySigner = (envOverrides: KeeperSignerEnv = {}, chainOverrides: Record<string, unknown> = {}) => {
+  const fetchMock = vi.fn<typeof fetch>(
+    async () => new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: TX_HASH })),
+  )
+  const signer = createKeeperSigner(
+    readKeeperSignerConfig({ ...baseEnv, PRIVATE_TX_RELAY_URL: RELAY_URL, ...envOverrides }),
+    { publicClient: makeChainStub(chainOverrides), fetchFn: fetchMock },
+  )
+  return { signer, fetchMock }
+}
+
+describe("readKeeperSignerConfig", () => {
+  it("degrades to safe defaults when nothing is configured", () => {
+    const config = readKeeperSignerConfig({})
+    expect(config.chainId).toBeNull()
+    expect(config.privateKey).toBeNull()
+    expect(config.rpcUrl).toBeNull()
+    expect(config.maxGasPriceGwei).toBeNull()
+    expect(config.minBalanceWei).toBe(parseEther("0.05"))
+    expect(config.privateRelayUrl).toBeNull()
+    expect(config.allowPublicSubmission).toBe(false)
+    expect(config.tpslAddress).toBeNull()
+  })
+
+  it("normalizes private keys (accepts missing 0x prefix, lowercases)", () => {
+    const config = readKeeperSignerConfig({
+      KEEPER_PRIVATE_KEY: "11".repeat(32),
+    })
+    expect(config.privateKey).toBe(TEST_PRIVATE_KEY)
+  })
+
+  it("rejects malformed private keys", () => {
+    expect(readKeeperSignerConfig({ KEEPER_PRIVATE_KEY: "0x1234" }).privateKey).toBeNull()
+    expect(readKeeperSignerConfig({ KEEPER_PRIVATE_KEY: "not-a-key" }).privateKey).toBeNull()
+  })
+
+  it("accepts only https relay URLs", () => {
+    expect(parseRelayUrl("https://relay.example/submit")).toBe("https://relay.example/submit")
+    expect(parseRelayUrl("http://relay.example/submit")).toBeNull()
+    expect(parseRelayUrl("ws://relay.example")).toBeNull()
+    expect(parseRelayUrl("not a url")).toBeNull()
+    expect(parseRelayUrl("   ")).toBeNull()
+    expect(readKeeperSignerConfig({ PRIVATE_TX_RELAY_URL: "http://insecure.example" }).privateRelayUrl).toBeNull()
+  })
+
+  it("only enables public submission on an explicit 'true'", () => {
+    expect(readKeeperSignerConfig({ KEEPER_ALLOW_PUBLIC_SUBMISSION: "true" }).allowPublicSubmission).toBe(true)
+    expect(readKeeperSignerConfig({ KEEPER_ALLOW_PUBLIC_SUBMISSION: " TRUE " }).allowPublicSubmission).toBe(true)
+    expect(readKeeperSignerConfig({ KEEPER_ALLOW_PUBLIC_SUBMISSION: "false" }).allowPublicSubmission).toBe(false)
+    expect(readKeeperSignerConfig({ KEEPER_ALLOW_PUBLIC_SUBMISSION: "1" }).allowPublicSubmission).toBe(false)
+    expect(readKeeperSignerConfig({}).allowPublicSubmission).toBe(false)
+  })
+
+  it("parses the gas funding floor and falls back to 0.05 ETH on garbage", () => {
+    expect(readKeeperSignerConfig({ KEEPER_MIN_BALANCE_ETH: "0.2" }).minBalanceWei).toBe(parseEther("0.2"))
+    expect(readKeeperSignerConfig({ KEEPER_MIN_BALANCE_ETH: "abc" }).minBalanceWei).toBe(parseEther("0.05"))
+    expect(readKeeperSignerConfig({ KEEPER_MIN_BALANCE_ETH: "-1" }).minBalanceWei).toBe(parseEther("0.05"))
+  })
+
+  it("parses the gas price ceiling", () => {
+    expect(readKeeperSignerConfig({ KEEPER_MAX_GAS_PRICE_GWEI: "25" }).maxGasPriceGwei).toBe(25)
+    expect(readKeeperSignerConfig({ KEEPER_MAX_GAS_PRICE_GWEI: "-5" }).maxGasPriceGwei).toBeNull()
+    expect(readKeeperSignerConfig({}).maxGasPriceGwei).toBeNull()
+  })
+
+  it("resolves the TPSL address (TPSL_ADDRESS wins, invalid rejected)", () => {
+    const good = "0x1111111111111111111111111111111111111111"
+    const other = "0x2222222222222222222222222222222222222222"
+    expect(resolveTpslAddress({ TPSL_ADDRESS: good, AETHER_TPSL_ADDRESS: other })).toBe(good)
+    expect(resolveTpslAddress({ AETHER_TPSL_ADDRESS: other })).toBe(other)
+    expect(resolveTpslAddress({ TPSL_ADDRESS: "0xnope", AETHER_TPSL_ADDRESS: "also-nope" })).toBeNull()
+    expect(resolveTpslAddress({})).toBeNull()
+  })
+
+  it("parses the chain id defensively", () => {
+    expect(readKeeperSignerConfig({ CHAIN_ID: "11155111" }).chainId).toBe(11155111)
+    expect(readKeeperSignerConfig({ CHAIN_ID: "0" }).chainId).toBeNull()
+    expect(readKeeperSignerConfig({ CHAIN_ID: "abc" }).chainId).toBeNull()
+  })
+})
+
+describe("authorization policy helpers", () => {
+  const now = 1_700_000_000_000
+  const base = {
+    status: "pending",
+    deadline: now + 60_000,
+    chainId: 11155111,
+    amountIn: "1000",
+  }
+  const policy = { expectedChainId: 11155111 }
+
+  it("authorizes a pending, unexpired, chain-matched order", () => {
+    expect(canExecuteTpSlOrder(base, policy, now)).toBe(true)
+  })
+
+  it("rejects anything not pending", () => {
+    expect(canExecuteTpSlOrder({ ...base, status: "triggered" }, policy, now)).toBe(false)
+    expect(canExecuteTpSlOrder({ ...base, status: "executed" }, policy, now)).toBe(false)
+    expect(canExecuteTpSlOrder({ ...base, status: "cancelled" }, policy, now)).toBe(false)
+  })
+
+  it("rejects expired deadlines", () => {
+    expect(canExecuteTpSlOrder({ ...base, deadline: now }, policy, now)).toBe(false)
+    expect(canExecuteTpSlOrder({ ...base, deadline: now - 1 }, policy, now)).toBe(false)
+    expect(canExecuteTpSlOrder({ ...base, deadline: Number.NaN }, policy, now)).toBe(false)
+  })
+
+  it("rejects chain mismatches", () => {
+    expect(canExecuteTpSlOrder(base, { expectedChainId: 1 }, now)).toBe(false)
+    expect(canExecuteTpSlOrder({ ...base, chainId: 1.5 }, policy, now)).toBe(false)
+  })
+
+  it("enforces the amount cap when the policy carries one", () => {
+    expect(canExecuteTpSlOrder(base, { ...policy, maxAmountIn: 500n }, now)).toBe(false)
+    expect(canExecuteTpSlOrder(base, { ...policy, maxAmountIn: 1000n }, now)).toBe(true)
+    expect(canExecuteTpSlOrder(base, { ...policy, maxAmountIn: 5000n }, now)).toBe(true)
+    expect(canExecuteTpSlOrder({ ...base, amountIn: "xyz" }, { ...policy, maxAmountIn: 5000n }, now)).toBe(false)
+  })
+
+  it("authorizes recenter only for active policies", () => {
+    expect(canExecuteRecenter({ isActive: true })).toBe(true)
+    expect(canExecuteRecenter({ isActive: 1 })).toBe(true)
+    expect(canExecuteRecenter({ isActive: false })).toBe(false)
+    expect(canExecuteRecenter({ isActive: 0 })).toBe(false)
+  })
+})
+
+describe("createKeeperSigner channel selection", () => {
+  it("stays evaluation-only without a private key", async () => {
+    const signer = createKeeperSigner(readKeeperSignerConfig({ ...baseEnv, KEEPER_PRIVATE_KEY: undefined }))
+    expect(signer.channel).toBe("evaluation-only")
+    expect(signer.address).toBeNull()
+    expect(await signer.sendTransaction({ to: "0x1111111111111111111111111111111111111111", data: "0x" })).toEqual({
+      kind: "submission-disabled",
+      reason: expect.stringContaining("KEEPER_PRIVATE_KEY"),
+    })
+  })
+
+  it("stays evaluation-only without an RPC URL", async () => {
+    const signer = createKeeperSigner(readKeeperSignerConfig({ ...baseEnv, KEEPER_RPC_URL: undefined }))
+    expect(signer.channel).toBe("evaluation-only")
+    expect(await signer.sendTransaction({ to: "0x1111111111111111111111111111111111111111", data: "0x" })).toEqual({
+      kind: "submission-disabled",
+      reason: expect.stringContaining("KEEPER_RPC_URL"),
+    })
+  })
+
+  it("stays evaluation-only without a chain id (no chain-scoped signing)", async () => {
+    const signer = createKeeperSigner(readKeeperSignerConfig({ ...baseEnv, CHAIN_ID: undefined }))
+    expect(signer.channel).toBe("evaluation-only")
+  })
+
+  it("defaults to evaluation-only when neither relay nor public opt-in is present", async () => {
+    const signer = createKeeperSigner(readKeeperSignerConfig(baseEnv))
+    expect(signer.channel).toBe("evaluation-only")
+    expect(signer.address).toBe(TEST_ADDRESS)
+    expect(
+      await signer.sendTransaction({ to: "0x1111111111111111111111111111111111111111", data: "0x" }),
+    ).toMatchObject({
+      kind: "submission-disabled",
+    })
+  })
+
+  it("selects the private relay channel when PRIVATE_TX_RELAY_URL is https", () => {
+    const signer = createKeeperSigner(readKeeperSignerConfig({ ...baseEnv, PRIVATE_TX_RELAY_URL: RELAY_URL }))
+    expect(signer.channel).toBe("private-relay")
+    expect(signer.address).toBe(TEST_ADDRESS)
+  })
+
+  it("selects the public channel only on explicit opt-in", () => {
+    const signer = createKeeperSigner(readKeeperSignerConfig({ ...baseEnv, KEEPER_ALLOW_PUBLIC_SUBMISSION: "true" }))
+    expect(signer.channel).toBe("public")
+  })
+})
+
+describe("private relay submission (mocked fetch)", () => {
+  it("signs locally and POSTs eth_sendRawTransaction to the https relay", async () => {
+    const { signer, fetchMock } = makeRelaySigner()
+
+    const result = await signer.sendTransaction({
+      to: "0x1111111111111111111111111111111111111111",
+      data: "0xabcdef",
+      chainId: 11155111,
+    })
+
+    expect(result).toEqual({ kind: "submitted", channel: "private-relay", txHash: TX_HASH })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(RELAY_URL)
+    expect(new URL(String(url)).protocol).toBe("https:")
+    expect(init?.method).toBe("POST")
+    expect(init?.headers).toMatchObject({ "content-type": "application/json" })
+
+    const body = JSON.parse(String(init?.body)) as { jsonrpc: string; method: string; params: string[] }
+    expect(body.jsonrpc).toBe("2.0")
+    expect(body.method).toBe("eth_sendRawTransaction")
+    expect(body.params).toHaveLength(1)
+    expect(body.params[0]).toMatch(/^0x[0-9a-fA-F]{2,}$/)
+  })
+
+  it("never sends to a non-https relay (config rejects it)", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({ result: TX_HASH })))
+    const signer = createKeeperSigner(
+      readKeeperSignerConfig({ ...baseEnv, PRIVATE_TX_RELAY_URL: "http://insecure.example" }),
+      { fetchFn: fetchMock },
+    )
+    expect(signer.channel).toBe("evaluation-only")
+    const result = await signer.sendTransaction({ to: "0x1111111111111111111111111111111111111111", data: "0x" })
+    expect(result.kind).toBe("submission-disabled")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("surfaces relay JSON-RPC rejections as non-retryable", async () => {
+    const relayError = { jsonrpc: "2.0", id: 1, error: { code: -32000, message: "underpriced" } }
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(JSON.stringify(relayError)))
+    const signer = createKeeperSigner(readKeeperSignerConfig({ ...baseEnv, PRIVATE_TX_RELAY_URL: RELAY_URL }), {
+      publicClient: makeChainStub(),
+      fetchFn: fetchMock,
+    })
+    await expect(
+      signer.sendTransaction({ to: "0x1111111111111111111111111111111111111111", data: "0x", chainId: 11155111 }),
+    ).rejects.toThrow(/underpriced/)
+  })
+
+  it("marks relay 5xx as retryable and 4xx as deterministic", async () => {
+    for (const [status, retryable] of [
+      [503, true],
+      [429, false],
+    ] as const) {
+      const fetchMock = vi.fn<typeof fetch>(async () => new Response("busy", { status }))
+      const signer = createKeeperSigner(readKeeperSignerConfig({ ...baseEnv, PRIVATE_TX_RELAY_URL: RELAY_URL }), {
+        publicClient: makeChainStub(),
+        fetchFn: fetchMock,
+      })
+      await expect(
+        signer.sendTransaction({ to: "0x1111111111111111111111111111111111111111", data: "0x", chainId: 11155111 }),
+      ).rejects.toSatisfy((error: unknown) => error instanceof KeeperRelayError && error.retryable === retryable)
+    }
+  })
+
+  it("rejects a relay response without a valid tx hash", async () => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () => new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0xzz" })),
+    )
+    const signer = createKeeperSigner(readKeeperSignerConfig({ ...baseEnv, PRIVATE_TX_RELAY_URL: RELAY_URL }), {
+      publicClient: makeChainStub(),
+      fetchFn: fetchMock,
+    })
+    await expect(
+      signer.sendTransaction({ to: "0x1111111111111111111111111111111111111111", data: "0x", chainId: 11155111 }),
+    ).rejects.toThrow(/transaction hash/)
+  })
+})
+
+describe("preflight guards", () => {
+  const input = { to: "0x1111111111111111111111111111111111111111" as const, data: "0x" as const, chainId: 11155111 }
+
+  it("blocks submission when the keeper balance is below the funding floor", async () => {
+    const { signer, fetchMock } = makeRelaySigner({}, { getBalance: async () => 0n })
+    await expect(signer.sendTransaction(input)).rejects.toSatisfy(
+      (error: unknown) => error instanceof InsufficientKeeperBalanceError && error.minimumWei === parseEther("0.05"),
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(isTransientKeeperError(new InsufficientKeeperBalanceError("0x", 0n, 1n))).toBe(false)
+  })
+
+  it("blocks submission when gas price exceeds the ceiling", async () => {
+    const { signer, fetchMock } = makeRelaySigner(
+      { KEEPER_MAX_GAS_PRICE_GWEI: "1" },
+      { getGasPrice: async () => parseGwei("5") },
+    )
+    await expect(signer.sendTransaction(input)).rejects.toBeInstanceOf(GasPriceExceededError)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("passes when gas price is at the ceiling", async () => {
+    const { signer } = makeRelaySigner({ KEEPER_MAX_GAS_PRICE_GWEI: "5" }, { getGasPrice: async () => parseGwei("5") })
+    await expect(signer.sendTransaction(input)).resolves.toMatchObject({ kind: "submitted" })
+  })
+
+  it("rejects a chain mismatch before any RPC write", async () => {
+    const { signer, fetchMock } = makeRelaySigner()
+    await expect(signer.sendTransaction({ ...input, chainId: 1 })).rejects.toBeInstanceOf(KeeperChainMismatchError)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("wraps RPC failures as transient KeeperRpcError", async () => {
+    const { signer } = makeRelaySigner({}, { getTransactionCount: async () => Promise.reject(new Error("boom")) })
+    await expect(signer.sendTransaction(input)).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(KeeperRpcError)
+      return isTransientKeeperError(error)
+    })
+  })
+})
+
+describe("explicit public submission", () => {
+  it("sends through the wallet client with nonce/gas from preflight", async () => {
+    const sendTransaction = vi.fn(async () => TX_HASH)
+    const signer = createKeeperSigner(readKeeperSignerConfig({ ...baseEnv, KEEPER_ALLOW_PUBLIC_SUBMISSION: "true" }), {
+      publicClient: {
+        getBalance: async () => parseEther("1"),
+        getTransactionCount: async () => 7,
+        estimateGas: async () => 120_000n,
+        getGasPrice: async () => parseGwei("2"),
+      },
+      walletClient: { sendTransaction },
+    })
+
+    const result = await signer.sendTransaction({
+      to: "0x1111111111111111111111111111111111111111",
+      data: "0xdeadbeef",
+      chainId: 11155111,
+    })
+
+    expect(result).toEqual({ kind: "submitted", channel: "public", txHash: TX_HASH })
+    expect(sendTransaction).toHaveBeenCalledTimes(1)
+    expect(sendTransaction.mock.calls[0][0]).toMatchObject({
+      chain: null,
+      to: "0x1111111111111111111111111111111111111111",
+      data: "0xdeadbeef",
+      nonce: 7,
+      gas: 120_000n,
+      gasPrice: parseGwei("2"),
+    })
+  })
+
+  it("never touches the wallet client while evaluation-only", async () => {
+    const sendTransaction = vi.fn(async () => TX_HASH)
+    const signer = createKeeperSigner(readKeeperSignerConfig(baseEnv), { walletClient: { sendTransaction } })
+    await signer.sendTransaction({ to: "0x1111111111111111111111111111111111111111", data: "0x" })
+    expect(sendTransaction).not.toHaveBeenCalled()
+  })
+})
+
+describe("encodeExecuteOrder", () => {
+  it("encodes AetherTPSL.executeOrder calldata with the right selector", () => {
+    const selector = toFunctionSelector("function executeOrder(uint256,bytes)")
+    const data = encodeExecuteOrder(42)
+    expect(data.startsWith(selector)).toBe(true)
+    expect(encodeExecuteOrder(42n)).toBe(data)
+    expect(encodeExecuteOrder(43)).not.toBe(data)
+    expect(encodeExecuteOrder(42, "0x1234")).not.toBe(data)
+  })
+
+  it("rejects negative order ids", () => {
+    expect(() => encodeExecuteOrder(-1)).toThrow(RangeError)
+  })
+})

--- a/apps/api/test/keeper-signer.test.ts
+++ b/apps/api/test/keeper-signer.test.ts
@@ -5,7 +5,7 @@
  * balance / gas / chain preflight guards. No network access.
  */
 
-import { parseEther, parseGwei, toFunctionSelector } from "viem"
+import { keccak256, parseEther, parseGwei, toBytes, toFunctionSelector } from "viem"
 import { describe, expect, it, vi } from "vitest"
 import {
   canExecuteRecenter,
@@ -296,6 +296,48 @@ describe("private relay submission (mocked fetch)", () => {
       signer.sendTransaction({ to: "0x1111111111111111111111111111111111111111", data: "0x", chainId: 11155111 }),
     ).rejects.toThrow(/transaction hash/)
   })
+
+  it("confirms a relay transaction only after the execution event is mined", async () => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () => new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: TX_HASH })),
+    )
+    const signer = createKeeperSigner(readKeeperSignerConfig({ ...baseEnv, PRIVATE_TX_RELAY_URL: RELAY_URL }), {
+      publicClient: {
+        ...makeChainStub(),
+        waitForTransactionReceipt: async () => ({
+          status: "success" as const,
+          logs: [
+            {
+              address: "0x1111111111111111111111111111111111111111",
+              topics: [keccak256(toBytes("OrderExecuted(uint256,address,uint256,uint256)"))],
+            },
+          ],
+        }),
+      },
+      fetchFn: fetchMock,
+    })
+
+    await expect(
+      signer.sendTransaction({ to: "0x1111111111111111111111111111111111111111", data: "0x" }),
+    ).resolves.toEqual({ kind: "submitted", channel: "private-relay", txHash: TX_HASH, confirmed: true })
+  })
+
+  it("rejects a mined transaction that reverted", async () => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () => new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: TX_HASH })),
+    )
+    const signer = createKeeperSigner(readKeeperSignerConfig({ ...baseEnv, PRIVATE_TX_RELAY_URL: RELAY_URL }), {
+      publicClient: {
+        ...makeChainStub(),
+        waitForTransactionReceipt: async () => ({ status: "reverted" as const, logs: [] }),
+      },
+      fetchFn: fetchMock,
+    })
+
+    await expect(
+      signer.sendTransaction({ to: "0x1111111111111111111111111111111111111111", data: "0x" }),
+    ).rejects.toThrow(/reverted/)
+  })
 })
 
 describe("preflight guards", () => {
@@ -375,6 +417,29 @@ describe("explicit public submission", () => {
     const signer = createKeeperSigner(readKeeperSignerConfig(baseEnv), { walletClient: { sendTransaction } })
     await signer.sendTransaction({ to: "0x1111111111111111111111111111111111111111", data: "0x" })
     expect(sendTransaction).not.toHaveBeenCalled()
+  })
+
+  it("serializes concurrent submissions and allocates distinct pending nonces", async () => {
+    const sendTransaction = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      return TX_HASH
+    })
+    const signer = createKeeperSigner(readKeeperSignerConfig({ ...baseEnv, KEEPER_ALLOW_PUBLIC_SUBMISSION: "true" }), {
+      publicClient: {
+        getBalance: async () => parseEther("1"),
+        getTransactionCount: async () => 7,
+        estimateGas: async () => 120_000n,
+        getGasPrice: async () => parseGwei("2"),
+      },
+      walletClient: { sendTransaction },
+    })
+
+    await Promise.all([
+      signer.sendTransaction({ to: "0x1111111111111111111111111111111111111111", data: "0x" }),
+      signer.sendTransaction({ to: "0x1111111111111111111111111111111111111111", data: "0x" }),
+    ])
+
+    expect(sendTransaction.mock.calls.map(([args]) => args.nonce)).toEqual([7, 8])
   })
 })
 

--- a/apps/api/test/keeper-tpsl-evaluate.test.ts
+++ b/apps/api/test/keeper-tpsl-evaluate.test.ts
@@ -17,6 +17,7 @@ import m0005PoolKeys from "../migrations/0005_chain_qualified_pool_keys.sql?raw"
 import m0005TpSl from "../migrations/0005_tp_sl_orders.sql?raw"
 import m0006 from "../migrations/0006_chain_qualified_price_cache.sql?raw"
 import m0007 from "../migrations/0007_v3_indexer_cursor.sql?raw"
+import m0008 from "../migrations/0008_tp_sl_onchain_order_id.sql?raw"
 import {
   encodeExecuteOrder,
   InsufficientKeeperBalanceError,
@@ -31,7 +32,7 @@ import {
   type TpSlEvaluateMessage,
 } from "../src/workers/queue-handler"
 
-const MIGRATIONS = [m0001, m0002, m0003, m0004, m0005PoolKeys, m0005TpSl, m0006, m0007]
+const MIGRATIONS = [m0001, m0002, m0003, m0004, m0005PoolKeys, m0005TpSl, m0006, m0007, m0008]
 
 const splitStatements = (script: string): string[] =>
   script
@@ -68,7 +69,8 @@ const makeQueueEnv = (vars: Record<string, string> = { TPSL_ADDRESS }): QueueEnv
 
 const makeMessage = (overrides: Partial<TpSlEvaluateMessage> = {}): TpSlEvaluateMessage => ({
   type: "tp-sl-evaluate",
-  orderId: 1,
+  orderId: overrides.orderId ?? 1,
+  onchainOrderId: String((overrides.orderId ?? 1) - 1),
   poolId: poolIdFor(1),
   orderType: "take_profit",
   zeroForOne: false,
@@ -86,13 +88,13 @@ const makeMessage = (overrides: Partial<TpSlEvaluateMessage> = {}): TpSlEvaluate
 const seedOrder = async (
   orderId: number,
   poolId: string,
-  overrides: { deadline?: number; status?: string } = {},
+  overrides: { deadline?: number; status?: string; onchainOrderId?: string } = {},
 ): Promise<void> => {
   await env.DB.prepare(
     `INSERT INTO tp_sl_orders
        (id, user_address, pool_id, order_type, zero_for_one, amount_in, min_amount_out,
-        trigger_price_x18, twap_window, slippage_bps, deadline, status, created_at, chain_id)
-     VALUES (?, ?, ?, 'take_profit', 0, '1000000', '1', ?, 300, 500, ?, ?, ?, 11155111)`,
+        trigger_price_x18, twap_window, slippage_bps, deadline, status, created_at, chain_id, onchain_order_id)
+     VALUES (?, ?, ?, 'take_profit', 0, '1000000', '1', ?, 300, 500, ?, ?, ?, 11155111, ?)`,
   )
     .bind(
       orderId,
@@ -102,6 +104,7 @@ const seedOrder = async (
       overrides.deadline ?? Date.now() + 600_000,
       overrides.status ?? "pending",
       Date.now(),
+      overrides.onchainOrderId ?? String(orderId - 1),
     )
     .run()
 }
@@ -151,17 +154,17 @@ describe("processQueueBatch (tp-sl-evaluate)", () => {
     await seedOrder(1, poolId)
     await primePrices(poolId)
 
-    const signer = makeFakeSigner({ kind: "submitted", channel: "private-relay", txHash: TX_HASH })
+    const signer = makeFakeSigner({ kind: "submitted", channel: "private-relay", txHash: TX_HASH, confirmed: true })
     const { batch, ack, retry } = makeBatch(makeMessage({ orderId: 1, poolId }))
 
     await processQueueBatch(batch, makeQueueEnv(), undefined, signer.factory)
 
     expect(signer.sentInputs).toHaveLength(1)
     expect(signer.received()).toMatchObject({ to: TPSL_ADDRESS, chainId: 11155111 })
-    expect(signer.received()?.data).toBe(encodeExecuteOrder(1))
+    expect(signer.received()?.data).toBe(encodeExecuteOrder("0"))
 
     const order = await readOrder(1)
-    expect(order).toEqual({ status: "triggered", execution_tx_hash: TX_HASH })
+    expect(order).toEqual({ status: "executed", execution_tx_hash: TX_HASH })
     expect(ack).toHaveBeenCalledTimes(1)
     expect(retry).not.toHaveBeenCalled()
   })

--- a/apps/api/test/keeper-tpsl-evaluate.test.ts
+++ b/apps/api/test/keeper-tpsl-evaluate.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Phase 2/3 keeper relayer — TP/SL evaluate+execute orchestration through the
+ * real queue handler against the test D1 database, with a fake signer injected
+ * via the `signerFactory` seam. Verifies AetherTPSL.executeOrder encoding,
+ * the pending-preserved behaviour on disabled/deterministic failures, and
+ * queue retry on transient errors. No network access.
+ */
+
+import { env } from "cloudflare:test"
+import { parseEther } from "viem"
+import { beforeAll, describe, expect, it, vi } from "vitest"
+import m0001 from "../migrations/0001_initial_schema.sql?raw"
+import m0002 from "../migrations/0002_seed_data.sql?raw"
+import m0003 from "../migrations/0003_chain_scoped_tokens.sql?raw"
+import m0004 from "../migrations/0004_phase1_chain_and_events.sql?raw"
+import m0005PoolKeys from "../migrations/0005_chain_qualified_pool_keys.sql?raw"
+import m0005TpSl from "../migrations/0005_tp_sl_orders.sql?raw"
+import m0006 from "../migrations/0006_chain_qualified_price_cache.sql?raw"
+import m0007 from "../migrations/0007_v3_indexer_cursor.sql?raw"
+import {
+  encodeExecuteOrder,
+  InsufficientKeeperBalanceError,
+  KeeperRpcError,
+  type SendTransactionInput,
+  type SubmissionResult,
+} from "../src/lib/keeper-signer"
+import {
+  type KeeperSignerFactory,
+  processQueueBatch,
+  type QueueEnv,
+  type TpSlEvaluateMessage,
+} from "../src/workers/queue-handler"
+
+const MIGRATIONS = [m0001, m0002, m0003, m0004, m0005PoolKeys, m0005TpSl, m0006, m0007]
+
+const splitStatements = (script: string): string[] =>
+  script
+    .split("\n")
+    .map((line) => line.split("--")[0])
+    .join("\n")
+    .split(";")
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0 && !statement.startsWith("PRAGMA foreign_key_check"))
+
+beforeAll(async () => {
+  for (const script of MIGRATIONS) {
+    for (const statement of splitStatements(script)) {
+      await env.DB.prepare(statement).run()
+    }
+  }
+})
+
+const TPSL_ADDRESS = "0x1111111111111111111111111111111111111111"
+const USER_ADDRESS = "0x3333333333333333333333333333333333333333"
+const TX_HASH = `0x${"cd".repeat(32)}`
+const PRICES = { spot: "2000000000000000000", twap: "2000000000000000000", trigger: "1500000000000000000" }
+
+const poolIdFor = (index: number): string => `0x${String(index).padStart(64, "0")}`
+
+const makeQueueEnv = (vars: Record<string, string> = { TPSL_ADDRESS }): QueueEnv => ({
+  DB: env.DB,
+  CACHE: env.CACHE,
+  STORAGE: env.STORAGE,
+  WEBSOCKET_HUB: env.WEBSOCKET_HUB,
+  CHAIN_ID: "11155111",
+  ...vars,
+})
+
+const makeMessage = (overrides: Partial<TpSlEvaluateMessage> = {}): TpSlEvaluateMessage => ({
+  type: "tp-sl-evaluate",
+  orderId: 1,
+  poolId: poolIdFor(1),
+  orderType: "take_profit",
+  zeroForOne: false,
+  amountIn: "1000000",
+  minAmountOut: "1",
+  triggerPriceX18: PRICES.trigger,
+  twapWindow: 300,
+  slippageBps: 500,
+  deadline: Date.now() + 600_000,
+  userAddress: USER_ADDRESS,
+  chainId: 11155111,
+  ...overrides,
+})
+
+const seedOrder = async (
+  orderId: number,
+  poolId: string,
+  overrides: { deadline?: number; status?: string } = {},
+): Promise<void> => {
+  await env.DB.prepare(
+    `INSERT INTO tp_sl_orders
+       (id, user_address, pool_id, order_type, zero_for_one, amount_in, min_amount_out,
+        trigger_price_x18, twap_window, slippage_bps, deadline, status, created_at, chain_id)
+     VALUES (?, ?, ?, 'take_profit', 0, '1000000', '1', ?, 300, 500, ?, ?, ?, 11155111)`,
+  )
+    .bind(
+      orderId,
+      USER_ADDRESS,
+      poolId,
+      PRICES.trigger,
+      overrides.deadline ?? Date.now() + 600_000,
+      overrides.status ?? "pending",
+      Date.now(),
+    )
+    .run()
+}
+
+const primePrices = async (poolId: string): Promise<void> => {
+  await env.CACHE.put(`poolSpot:${poolId}`, JSON.stringify({ price: PRICES.spot }), { expirationTtl: 300 })
+  await env.CACHE.put(`twap:${poolId}:300`, JSON.stringify({ price: PRICES.twap }), { expirationTtl: 300 })
+}
+
+const readOrder = async (orderId: number) =>
+  env.DB.prepare("SELECT status, execution_tx_hash FROM tp_sl_orders WHERE id = ? AND chain_id = 11155111")
+    .bind(orderId)
+    .first<{ status: string; execution_tx_hash: string | null }>()
+
+const makeBatch = (body: unknown) => {
+  const ack = vi.fn()
+  const retry = vi.fn()
+  const batch = {
+    messages: [{ id: "msg-1", timestamp: new Date(), attempts: 1, body, ack, retry }],
+  } as unknown as MessageBatch<unknown>
+  return { batch, ack, retry }
+}
+
+interface FakeSignerHandle {
+  sentInputs: readonly SendTransactionInput[]
+  received: () => SendTransactionInput | undefined
+  factory: KeeperSignerFactory
+}
+
+const makeFakeSigner = (result: SubmissionResult | Error): FakeSignerHandle => {
+  const sentInputs: SendTransactionInput[] = []
+  const factory: KeeperSignerFactory = () => ({
+    address: "0x4444444444444444444444444444444444444444",
+    channel: "private-relay",
+    sendTransaction: async (input) => {
+      sentInputs.push(input)
+      if (result instanceof Error) throw result
+      return result
+    },
+  })
+  return { sentInputs, received: () => sentInputs[0], factory }
+}
+
+describe("processQueueBatch (tp-sl-evaluate)", () => {
+  it("submits AetherTPSL.executeOrder via the signer and records the tx hash when the dual trigger breaches", async () => {
+    const poolId = poolIdFor(1)
+    await seedOrder(1, poolId)
+    await primePrices(poolId)
+
+    const signer = makeFakeSigner({ kind: "submitted", channel: "private-relay", txHash: TX_HASH })
+    const { batch, ack, retry } = makeBatch(makeMessage({ orderId: 1, poolId }))
+
+    await processQueueBatch(batch, makeQueueEnv(), undefined, signer.factory)
+
+    expect(signer.sentInputs).toHaveLength(1)
+    expect(signer.received()).toMatchObject({ to: TPSL_ADDRESS, chainId: 11155111 })
+    expect(signer.received()?.data).toBe(encodeExecuteOrder(1))
+
+    const order = await readOrder(1)
+    expect(order).toEqual({ status: "triggered", execution_tx_hash: TX_HASH })
+    expect(ack).toHaveBeenCalledTimes(1)
+    expect(retry).not.toHaveBeenCalled()
+  })
+
+  it("keeps the order pending when submission is disabled (evaluation-only default)", async () => {
+    const poolId = poolIdFor(2)
+    await seedOrder(2, poolId)
+    await primePrices(poolId)
+
+    const signer = makeFakeSigner({
+      kind: "submission-disabled",
+      reason: "no relay and no public opt-in",
+    })
+    const { batch, ack, retry } = makeBatch(makeMessage({ orderId: 2, poolId }))
+
+    await processQueueBatch(batch, makeQueueEnv(), undefined, signer.factory)
+
+    expect(signer.sentInputs).toHaveLength(1)
+    const order = await readOrder(2)
+    expect(order).toEqual({ status: "pending", execution_tx_hash: null })
+    expect(ack).toHaveBeenCalledTimes(1)
+    expect(retry).not.toHaveBeenCalled()
+  })
+
+  it("keeps the order pending without a queue retry on deterministic guard failures", async () => {
+    const poolId = poolIdFor(3)
+    await seedOrder(3, poolId)
+    await primePrices(poolId)
+
+    const signer = makeFakeSigner(new InsufficientKeeperBalanceError("0x", 0n, parseEther("0.05")))
+    const { batch, ack, retry } = makeBatch(makeMessage({ orderId: 3, poolId }))
+
+    await processQueueBatch(batch, makeQueueEnv(), undefined, signer.factory)
+
+    const order = await readOrder(3)
+    expect(order).toEqual({ status: "pending", execution_tx_hash: null })
+    expect(ack).toHaveBeenCalledTimes(1)
+    expect(retry).not.toHaveBeenCalled()
+  })
+
+  it("retries the queue message on transient RPC failures", async () => {
+    const poolId = poolIdFor(4)
+    await seedOrder(4, poolId)
+    await primePrices(poolId)
+
+    const signer = makeFakeSigner(new KeeperRpcError("rpc down"))
+    const { batch, ack, retry } = makeBatch(makeMessage({ orderId: 4, poolId }))
+
+    await processQueueBatch(batch, makeQueueEnv(), undefined, signer.factory)
+
+    const order = await readOrder(4)
+    expect(order).toEqual({ status: "pending", execution_tx_hash: null })
+    expect(retry).toHaveBeenCalledTimes(1)
+    expect(ack).not.toHaveBeenCalled()
+  })
+
+  it("stays evaluation-only when no TPSL address is configured", async () => {
+    const poolId = poolIdFor(5)
+    await seedOrder(5, poolId)
+    await primePrices(poolId)
+
+    const factory = vi.fn<KeeperSignerFactory>(() => {
+      throw new Error("signer must not be created without a TPSL address")
+    })
+    const { batch, ack } = makeBatch(makeMessage({ orderId: 5, poolId }))
+
+    await processQueueBatch(batch, makeQueueEnv({}), undefined, factory)
+
+    expect(factory).not.toHaveBeenCalled()
+    const order = await readOrder(5)
+    expect(order).toEqual({ status: "pending", execution_tx_hash: null })
+    expect(ack).toHaveBeenCalledTimes(1)
+  })
+
+  it("blocks execution when the order chain does not match the configured CHAIN_ID", async () => {
+    const poolId = poolIdFor(6)
+    await seedOrder(6, poolId)
+    await primePrices(poolId)
+
+    const factory = vi.fn<KeeperSignerFactory>(() => {
+      throw new Error("signer must not be created on a chain mismatch")
+    })
+    const { batch, ack } = makeBatch(makeMessage({ orderId: 6, poolId }))
+
+    await processQueueBatch(batch, makeQueueEnv({ TPSL_ADDRESS, CHAIN_ID: "1" }), undefined, factory)
+
+    expect(factory).not.toHaveBeenCalled()
+    const order = await readOrder(6)
+    expect(order).toEqual({ status: "pending", execution_tx_hash: null })
+    expect(ack).toHaveBeenCalledTimes(1)
+  })
+
+  it("marks expired orders and never invokes the signer", async () => {
+    const poolId = poolIdFor(7)
+    const past = Date.now() - 60_000
+    await seedOrder(7, poolId, { deadline: past })
+    await primePrices(poolId)
+
+    const factory = vi.fn<KeeperSignerFactory>(() => {
+      throw new Error("signer must not be created for an expired order")
+    })
+    const { batch, ack } = makeBatch(makeMessage({ orderId: 7, poolId, deadline: past }))
+
+    await processQueueBatch(batch, makeQueueEnv(), undefined, factory)
+
+    expect(factory).not.toHaveBeenCalled()
+    const order = await readOrder(7)
+    expect(order?.status).toBe("expired")
+    expect(ack).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/api/test/volume-alerts.test.ts
+++ b/apps/api/test/volume-alerts.test.ts
@@ -391,7 +391,7 @@ describe("VolumeAlertHubDO broadcast", () => {
     allWs.close(1000, "done")
     xWs.close(1000, "done")
     yWs.close(1000, "done")
-  })
+  }, 20_000)
 
   it("canonicalizes a mixed-case pool id on the per-pool route", async () => {
     const hubNs = env.VOLUME_ALERT_HUB
@@ -410,7 +410,7 @@ describe("VolumeAlertHubDO broadcast", () => {
 
     expect(msgs.map((m) => m.poolId)).toEqual([lower])
     ws.close(1000, "done")
-  })
+  }, 20_000)
 
   it("answers a ping with a pong", async () => {
     const ws = await connect("/ws/alerts")

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -148,6 +148,15 @@
     "INDEXER_BATCH_SIZE": "2000",
     "V4_POOL_MANAGER_ADDRESS": "",
     "V3_INDEXED_POOL_ADDRESSES": "",
+    // Phase 2/3 keeper relayer (src/lib/keeper-signer.ts). Submission stays
+    // EVALUATION-ONLY until PRIVATE_TX_RELAY_URL is set (https MEV Tier-B relay;
+    // preferred) or KEEPER_ALLOW_PUBLIC_SUBMISSION is explicitly "true".
+    // Secrets KEEPER_PRIVATE_KEY + KEEPER_RPC_URL go via `wrangler secret put`.
+    "TPSL_ADDRESS": "",
+    "AETHER_TPSL_ADDRESS": "",
+    "KEEPER_ALLOW_PUBLIC_SUBMISSION": "false",
+    "KEEPER_MIN_BALANCE_ETH": "0.05",
+    "KEEPER_MAX_GAS_PRICE_GWEI": "",
     // "auto" = V4 tick-math when STATE_VIEW_ADDRESS+RPC_URL are set, else legacy D1 approximation.
     "QUOTE_ENGINE_MODE": "auto",
     // Canonical Uniswap default token list (Phase-0 G4) — the only token list AetherDEX serves.
@@ -170,9 +179,11 @@
     "ENVIRONMENT": "development"
   },
 
-  // Phase 2 keeper secrets (set via `wrangler secret put`):
-  //   KEEPER_PRIVATE_KEY — hex-encoded private key for keeper transaction signing
-  //   KEEPER_RPC_URL — RPC endpoint used by the keeper to submit transactions
+  // Phase 2/3 keeper relayer secrets (set via `wrangler secret put`):
+  //   KEEPER_PRIVATE_KEY — hex-encoded private key; loaded for local signing only, never logged
+  //   KEEPER_RPC_URL — RPC endpoint used for preflight reads + public submission when enabled
+  // Submission stays evaluation-only unless PRIVATE_TX_RELAY_URL (https-only,
+  // MEV Tier-B private relay; preferred) or KEEPER_ALLOW_PUBLIC_SUBMISSION="true".
   //
   // Phase 3 volume-alert Telegram notifications (set via `wrangler secret put`):
   //   TELEGRAM_BOT_TOKEN — bot API token; alerts stay off until this is set
@@ -204,6 +215,11 @@
         "INDEXER_BATCH_SIZE": "2000",
         "V4_POOL_MANAGER_ADDRESS": "",
         "V3_INDEXED_POOL_ADDRESSES": "",
+        "TPSL_ADDRESS": "",
+        "AETHER_TPSL_ADDRESS": "",
+        "KEEPER_ALLOW_PUBLIC_SUBMISSION": "false",
+        "KEEPER_MIN_BALANCE_ETH": "0.05",
+        "KEEPER_MAX_GAS_PRICE_GWEI": "",
         "QUOTE_ENGINE_MODE": "auto",
         "TOKEN_LIST_URL": "https://tokens.uniswap.org",
         "RATE_LIMIT_MAX": "60",
@@ -301,6 +317,11 @@
         "INDEXER_BATCH_SIZE": "2000",
         "V4_POOL_MANAGER_ADDRESS": "",
         "V3_INDEXED_POOL_ADDRESSES": "",
+        "TPSL_ADDRESS": "",
+        "AETHER_TPSL_ADDRESS": "",
+        "KEEPER_ALLOW_PUBLIC_SUBMISSION": "false",
+        "KEEPER_MIN_BALANCE_ETH": "0.05",
+        "KEEPER_MAX_GAS_PRICE_GWEI": "",
         "QUOTE_ENGINE_MODE": "auto",
         "TOKEN_LIST_URL": "https://tokens.uniswap.org",
         "RATE_LIMIT_MAX": "60",

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -13,6 +13,9 @@ gas_reports = ["AetherRouter", "AetherFactory", "AetherHook"]
 auto_detect_solc = true
 revert_strings = "strip"
 
+[rpc_endpoints]
+sepolia = "${SEPOLIA_RPC_URL}"
+
 [profile.default.fuzz]
 runs = 1000
 

--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -122,7 +122,7 @@ contract Deploy is Script {
             bytes memory hookCtorArgs = abi.encode(IPoolManager(poolManager));
             bytes32 hookInitCodeHash = keccak256(abi.encodePacked(type(AetherHook).creationCode, hookCtorArgs));
             (bool saltFound, bytes32 hookSalt,) =
-                AetherHookAddressMiner.findSalt(deployer, hookInitCodeHash, HOOK_SALT_MAX_ITERATIONS);
+                AetherHookAddressMiner.findSalt(CREATE2_FACTORY, hookInitCodeHash, HOOK_SALT_MAX_ITERATIONS);
             require(saltFound, "Deploy: no CREATE2 salt satisfies BEFORE_SWAP|AFTER_SWAP flags");
             hookAddr = address(new AetherHook{salt: hookSalt}(IPoolManager(poolManager)));
             // Fail loudly if the deployed address does not encode exactly the implemented permissions.

--- a/packages/contracts/src/hook/AetherHookAddressMiner.sol
+++ b/packages/contracts/src/hook/AetherHookAddressMiner.sol
@@ -14,7 +14,7 @@ library AetherHookAddressMiner {
     /// @param hookAddress The deployed hook address to validate
     /// @return True if the address has BEFORE_SWAP_FLAG | AFTER_SWAP_FLAG set
     function hasValidFlags(address hookAddress) internal pure returns (bool) {
-        return uint160(hookAddress) & REQUIRED_FLAGS == REQUIRED_FLAGS;
+        return uint160(hookAddress) & Hooks.ALL_HOOK_MASK == REQUIRED_FLAGS;
     }
 
     /// @notice Find a CREATE2 salt that produces a hook address with the correct flags
@@ -34,7 +34,7 @@ library AetherHookAddressMiner {
             bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), deployer, currentSalt, initCodeHash));
             address candidate = address(uint160(uint256(hash)));
 
-            if (uint160(candidate) & REQUIRED_FLAGS == REQUIRED_FLAGS) {
+            if (uint160(candidate) & Hooks.ALL_HOOK_MASK == REQUIRED_FLAGS) {
                 return (true, currentSalt, candidate);
             }
         }

--- a/packages/contracts/test/unit/AetherHookAddressMiner.t.sol
+++ b/packages/contracts/test/unit/AetherHookAddressMiner.t.sol
@@ -11,6 +11,11 @@ contract AetherHookAddressMinerTest is Test {
         assertTrue(AetherHookAddressMiner.hasValidFlags(candidate));
     }
 
+    function test_hasValidFlags_rejectsAdditionalHookFlags() public pure {
+        address candidate = address(uint160(AetherHookAddressMiner.REQUIRED_FLAGS | Hooks.BEFORE_INITIALIZE_FLAG));
+        assertFalse(AetherHookAddressMiner.hasValidFlags(candidate));
+    }
+
     function test_hasValidFlags_rejectsMissingFlags() public pure {
         assertFalse(AetherHookAddressMiner.hasValidFlags(address(uint160(Hooks.BEFORE_SWAP_FLAG))));
         assertFalse(AetherHookAddressMiner.hasValidFlags(address(1)));


### PR DESCRIPTION
Implements the Phase 2/3 production keeper relayer gate from docs/exploration/alps-farm-refactor-plan.md (funded signer/relayer model + MEV Tier-B for unattended automation).

### Changes
- New `apps/api/src/lib/keeper-signer.ts`:
  - Env config parsing: KEEPER_PRIVATE_KEY (secret, never logged), KEEPER_RPC_URL, KEEPER_MAX_GAS_PRICE_GWEI, KEEPER_MIN_BALANCE_ETH (default 0.05 ETH), PRIVATE_TX_RELAY_URL (https only), KEEPER_ALLOW_PUBLIC_SUBMISSION (default false), TPSL/AETHER_TPSL address resolution.
  - viem account + clients; preflight guards (chain id match, balance floor, gas price cap) with typed errors.
  - Submission channels: private relay preferred (signed raw tx -> https eth_sendRawTransaction), explicit public opt-in, safe evaluation-only default otherwise.
  - Authorization policy helpers for TP/SL orders and recenter policies.
- Queue handler TP/SL path now executes `AetherTPSL.executeOrder` via the signer when configured; keeps orders pending (no state corruption) when submission is disabled; transient failures preserve queue retry behavior.
- index.ts passthrough + wrangler vars for keeper/TPSL config; secrets documented for `wrangler secret put`.
- Tests: config parsing, policy gates, relay submission (mocked fetch, asserts https + eth_sendRawTransaction), guards, and queue-handler orchestration with injected signer.

### Verification
- API: 26 files / 201 tests pass; lint + typecheck clean.
- Also includes a small stability fix: ignore alchemy local state dir and raise timeouts for two flaky DO websocket tests.

### Notes
- On-chain execution status stays `triggered` with `execution_tx_hash` recorded; reconciliation to `executed` is left to the indexer/verification path (verification gates not weakened).

## Summary by Sourcery

Introduce a keeper-funded signer/relayer for TP/SL on-chain execution with MEV Tier-B private submission, wire it into the TP/SL queue handler, and tighten hook deployment validation and testing.

New Features:
- Add a configurable keeper signer/relayer library that supports private relay and explicit public submission channels for automated on-chain TP/SL execution.
- Enable the TP/SL queue evaluation path to submit AetherTPSL.executeOrder transactions via the keeper signer and persist execution transaction hashes when triggers breach.

Bug Fixes:
- Restrict AetherHookAddressMiner flag validation to require exactly the intended hook permission bits, rejecting additional flags and updating the deploy script to use the CREATE2 factory address.

Enhancements:
- Add authorization policy helpers and preflight guards (chain, balance, gas price) for keeper-based executions while keeping evaluation-only behavior when misconfigured.
- Plumb keeper/TPSL-related environment variables through the API worker bindings and queue handler, with safe defaults when absent.
- Increase timeouts for flaky websocket-based volume alert tests and add a Sepolia RPC endpoint configuration for contracts tests.

Tests:
- Add comprehensive unit tests for the keeper signer configuration, policy gates, submission channels, and preflight behavior, including mocked private relay and public submission paths.
- Add integration-style tests for TP/SL evaluate-to-execute orchestration through the queue handler using a fake signer to verify status/tx-hash handling and retry semantics.
- Extend AetherHookAddressMiner tests to cover rejection of addresses with extra hook flags.