### PR TITLE
test(web): stabilize Playwright E2E and gate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,11 +358,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # ---------------------------------------------------------------------------
-  # Playwright E2E (apps/web test:e2e). Advisory for now: real failures show red on
-  # this job, but it is NOT wired into the ci-status gate until the suite stabilises.
+  # Playwright E2E (apps/web test:e2e). Stabilised in fix/e2e-stabilization: the suite
+  # runs against the Vite dev server with a one-time dev-server warm-up (globalSetup) and
+  # a fixture that aborts third-party WalletConnect/Reown + API requests, so first-mount
+  # latency and external-network variance no longer flake it. GATED by ci-status below.
   # ---------------------------------------------------------------------------
   e2e:
-    name: E2E (Playwright) — advisory
+    name: E2E (Playwright)
     runs-on: ubuntu-latest
     needs: detect-changes
     if: ${{ github.event_name != 'schedule' && needs.detect-changes.outputs.frontend == 'true' }}
@@ -507,7 +509,7 @@ jobs:
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
-    needs: [detect-changes, quality, contracts, backend, frontend]
+    needs: [detect-changes, quality, contracts, backend, frontend, e2e]
     if: ${{ github.event_name != 'schedule' && always() }}
     permissions:
       contents: read
@@ -519,6 +521,7 @@ jobs:
           CONTRACTS: ${{ needs.contracts.result }}
           BACKEND: ${{ needs.backend.result }}
           FRONTEND: ${{ needs.frontend.result }}
+          E2E: ${{ needs.e2e.result }}
         run: |
           set -euo pipefail
           fail=0
@@ -540,6 +543,7 @@ jobs:
           check "contracts" "${CONTRACTS}"
           check "backend" "${BACKEND}"
           check "frontend" "${FRONTEND}"
+          check "e2e" "${E2E}"
 
           if [ "${fail}" -ne 0 ]; then
             echo "One or more required jobs did not pass."

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -5,11 +5,27 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : 4,
+  // Dev-mode browsers each evaluate the heavy (unminified) dep graph, so concurrent
+  // cold mounts contend for CPU. Serialising in CI (1 worker) keeps it deterministic
+  // there; locally a small worker count bounds contention without a long run.
+  workers: process.env.CI ? 1 : 2,
+  // Pay Vite's one-time dep pre-bundle + entry transform once, out of band, before any
+  // test loads a page — otherwise the first browser navigation pays cold-compile cost.
+  globalSetup: "./test/e2e/global-setup.ts",
   reporter: [["html", { open: "never" }], ["list"]],
   use: {
     baseURL: "http://localhost:3000",
     trace: "on-first-retry",
+    // In dev mode React mounts asynchronously ~1-4s AFTER the `load` event that
+    // `page.goto` waits on (#root is empty at `load`). These are retry *bounds* for
+    // that async mount under worker contention — not sleeps; passing tests finish in
+    // ~1-3s. Without this headroom, first-mount races the element locators and flakes.
+    navigationTimeout: 45_000,
+    actionTimeout: 25_000,
+  },
+  timeout: 90_000,
+  expect: {
+    timeout: 25_000,
   },
   projects: [
     {

--- a/apps/web/src/routes/pools.new.tsx
+++ b/apps/web/src/routes/pools.new.tsx
@@ -318,14 +318,16 @@ function NewPoolPage() {
               </p>
             </div>
           </div>
-          <label className="label cursor-pointer justify-start gap-3">
+          <label className="label min-w-0 cursor-pointer justify-start gap-3">
             <input
               type="checkbox"
-              className="checkbox checkbox-primary"
+              className="checkbox flex-none checkbox-primary"
               checked={recheckAcknowledged}
               onChange={(e) => setRecheckAcknowledged(e.target.checked)}
             />
-            <span className="label-text">I understand the price will be checked again at execution time.</span>
+            <span className="label-text min-w-0 max-w-full whitespace-normal break-words">
+              I understand the price will be checked again at execution time.
+            </span>
           </label>
 
           {!config ? (

--- a/apps/web/test/e2e/fixtures.ts
+++ b/apps/web/test/e2e/fixtures.ts
@@ -1,0 +1,38 @@
+import { test as base } from "@playwright/test"
+
+/**
+ * Shared E2E fixture.
+ *
+ * The web app's wallet provider (Reown AppKit / WalletConnect) and its data layer
+ * (the `apps/api` Workers backend) both reach hosts that must NOT matter for these
+ * UI smoke tests. Left alone they:
+ *   - add variable external RTTs to app init (Reown config/usage/relay calls return
+ *     403 with the placeholder project id), and
+ *   - leave a WalletConnect relay connection in flight, which stops
+ *     `waitForLoadState("networkidle")` from ever resolving.
+ *
+ * Aborting those requests makes init fail fast and deterministically (the app already
+ * degrades gracefully on these paths), so tests exercise the rendered UI without
+ * depending on the public internet or a running API.
+ */
+const BLOCKED_PATTERNS: RegExp[] = [
+  // WalletConnect / Reown / Web3Modal cloud (relay, explorer, config, analytics).
+  /walletconnect\.(com|org)/,
+  /web3modal\.com/,
+  /reown\.com/,
+  // The backend API. Nothing listens on :8080 in E2E; abort instead of ECONNREFUSED so
+  // React Query's failed fetches resolve instantly rather than driving a retry storm.
+  /localhost:8080/,
+]
+
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await page.route(
+      (url) => BLOCKED_PATTERNS.some((pattern) => pattern.test(url.href)),
+      (route) => route.abort(),
+    )
+    await use(page)
+  },
+})
+
+export { expect } from "@playwright/test"

--- a/apps/web/test/e2e/global-setup.ts
+++ b/apps/web/test/e2e/global-setup.ts
@@ -1,0 +1,60 @@
+/**
+ * Playwright global setup — Vite dev-server warm-up.
+ *
+ * Why this exists: the E2E suite runs against the Vite dev server (`bun run dev`).
+ * The FIRST request after boot is slow two ways:
+ *   1. Vite's dependency pre-bundling (esbuild `optimizeDeps`) runs once and blocks
+ *      module requests until complete (measured ~12s on this app's heavy wagmi /
+ *      reown / uniswap-sdk dependency graph).
+ *   2. The entry module and its import graph are transformed on demand.
+ *
+ * When a test pays that cost inside `page.goto`, it can exceed the per-navigation
+ * timeout, and with parallel workers the compounding transforms turn it into a flaky
+ * "Test timeout exceeded" failure. We pay it once, out of band, here — where there is
+ * no test timeout — so every test then loads a fully warmed server in ~1s.
+ */
+
+const BASE_URL = process.env.BASE_URL ?? "http://localhost:3000"
+
+// Routes exercised by the specs, plus the Vite entry module. Fetching the entry
+// (/src/main.tsx) forces Vite to transform the root of the import graph and to
+// finish/optimize the pre-bundled dependency chunks that the browser will request.
+const WARM_TARGETS = ["/src/main.tsx", "/", "/swap", "/pools", "/pools/new", "/positions", "/portfolio", "/playground"]
+
+const READY_TIMEOUT_MS = 120_000
+const FETCH_TIMEOUT_MS = 90_000
+
+async function waitForServer(): Promise<void> {
+  const deadline = Date.now() + READY_TIMEOUT_MS
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(BASE_URL, { signal: AbortSignal.timeout(5_000) })
+      if (res.ok || res.status === 304) return
+      lastError = new Error(`non-ready status ${res.status}`)
+    } catch (error) {
+      lastError = error
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500))
+  }
+  throw new Error(
+    `Vite dev server did not become ready at ${BASE_URL} within ${READY_TIMEOUT_MS}ms: ${String(lastError)}`,
+  )
+}
+
+async function warm(target: string): Promise<void> {
+  try {
+    await fetch(`${BASE_URL}${target}`, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
+  } catch {
+    // Best-effort: warming only. A failed warm (e.g. an HTML fallback) must not fail
+    // the run — the tests themselves still assert the real behaviour with retries.
+  }
+}
+
+export default async function globalSetup(): Promise<void> {
+  await waitForServer()
+  // Warm sequentially enough to let optimizeDeps finish, then the rest can race.
+  await warm("/src/main.tsx")
+  await warm("/")
+  await Promise.all(WARM_TARGETS.slice(2).map(warm))
+}

--- a/apps/web/test/e2e/navigation.spec.ts
+++ b/apps/web/test/e2e/navigation.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test"
+import { expect, test } from "./fixtures"
 
 test.describe("Navigation", () => {
   test("home redirects to swap", async ({ page }) => {

--- a/apps/web/test/e2e/responsive.spec.ts
+++ b/apps/web/test/e2e/responsive.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test"
+import { expect, test } from "./fixtures"
 
 const routes = ["/swap", "/pools", "/pools/new", "/positions", "/portfolio"]
 

--- a/apps/web/test/e2e/swap.spec.ts
+++ b/apps/web/test/e2e/swap.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test"
+import { expect, test } from "./fixtures"
 
 test.describe("Swap page", () => {
   test.beforeEach(async ({ page }) => {

--- a/apps/web/test/e2e/visual.spec.ts
+++ b/apps/web/test/e2e/visual.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test"
+import { expect, test } from "./fixtures"
 
 test.describe("Visual QA", () => {
   test("swap page has no AI slop classes", async ({ page }) => {

--- a/biome.json
+++ b/biome.json
@@ -8,6 +8,7 @@
       "!**/node_modules",
       "!**/dist",
       "!**/.wrangler",
+      "!**/.alchemy",
       "!**/coverage",
       "!**/out",
       "!**/cache",


### PR DESCRIPTION
## Summary

The advisory E2E job failed consistently due to two root causes:

1. **Cold Vite dev-server compile**: the first browser load paid Vite's one-time dependency pre-bundle + entry transform (measured 12.5s cold vs 1s warm), racing the 30s test timeout and compounding under parallel workers.
2. **External network variance**: WalletConnect/Reown cloud requests and unreachable local API added nondeterministic latency.

## Fixes

- `test/e2e/global-setup.ts`: warms the dev server once before tests (pays cold-compile out of band).
- `test/e2e/fixtures.ts`: aborts third-party WalletConnect/Reown + API requests via `page.route`.
- `playwright.config.ts`: serialized CI workers, realistic navigation/action/expect timeouts (bounds, not sleeps).
- `pools.new.tsx`: narrow-viewport overflow fix.
- `.github/workflows/ci.yml`: E2E wired into the required `ci-status` gate.

## Verification

Two consecutive local runs: **17/17 passed** (45.7s and 50.7s).

## Summary by Sourcery

Stabilize the web app Playwright E2E suite and make it a required CI gate.

Enhancements:
- Adjust pools new-page acknowledgement label layout to wrap text correctly on narrow viewports.

CI:
- Promote the Playwright E2E job from advisory to required by wiring it into the ci-status gate and status aggregation.

Tests:
- Introduce a global Playwright setup that warms the Vite dev server before tests run to eliminate cold-start flakiness.
- Add a shared Playwright fixture that aborts external WalletConnect/Reown and backend API requests to remove external network variance from E2E runs.
- Update Playwright configuration to use global setup, tuned timeouts, and a reduced worker count, and migrate E2E specs to use the shared fixture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the layout and styling of the execution-time price re-check acknowledgement on the Pools page.

- **Tests**
  - Improved end-to-end test stability with server readiness checks, route warming, controlled concurrency, and blocked external requests.
  - Expanded navigation, responsive, swap, and visual testing coverage within the stabilized E2E workflow.

- **Chores**
  - E2E checks are now required for successful CI completion.
  - Updated tooling configuration to exclude Alchemy metadata from automated analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->