### PR TITLE
fix: close remaining phase 4 deployment review gaps

### DIFF
--- a/apps/web/src/components/PriceTicker.tsx
+++ b/apps/web/src/components/PriceTicker.tsx
@@ -50,7 +50,8 @@ export function PriceTicker({
   className = "",
   showVolume = false,
 }: PriceTickerProps) {
-  const configuredWsOrigin = import.meta.env.VITE_WS_URL ?? import.meta.env.VITE_API_URL ?? "ws://localhost:8080"
+  const configuredWsOrigin =
+    import.meta.env.VITE_WS_URL?.trim() || import.meta.env.VITE_API_URL?.trim() || "ws://localhost:8080"
   const wsOrigin = configuredWsOrigin
     .replace(/^http:/, "ws:")
     .replace(/^https:/, "wss:")

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -9,7 +9,7 @@ export const Route = createRootRoute({
 
 function RootComponent() {
   return (
-    <div className="min-h-screen bg-base-100">
+    <div className="min-h-screen min-w-0 overflow-x-clip bg-base-100">
       <header className="navbar border-b border-base-300 bg-base-200">
         <div className="container mx-auto flex flex-wrap items-center justify-between gap-4 px-4">
           <Link to="/" className="text-xl font-bold text-primary">
@@ -42,7 +42,7 @@ function RootComponent() {
           </div>
         </div>
       </header>
-      <main className="container mx-auto px-4 py-6">
+      <main className="container mx-auto min-w-0 px-4 py-6">
         <Outlet />
       </main>
       {import.meta.env.DEV && import.meta.env.VITE_SHOW_ROUTER_DEVTOOLS === "true" ? (

--- a/apps/web/src/routes/pools.new.tsx
+++ b/apps/web/src/routes/pools.new.tsx
@@ -187,7 +187,7 @@ function NewPoolPage() {
     submitted ? validation.errors[field] : undefined
 
   return (
-    <div className="mx-auto max-w-3xl py-8">
+    <div className="mx-auto min-w-0 max-w-3xl py-8">
       <div className="mb-6">
         <p className="mb-2 text-sm font-medium uppercase tracking-wide text-primary">Phase 1 · Pool creation</p>
         <h1 className="text-3xl font-bold">Create a new pool</h1>
@@ -309,8 +309,8 @@ function NewPoolPage() {
             onChange={(e) => update("deadline", e.target.value)}
           />
 
-          <div className="alert alert-warning items-start text-sm">
-            <div>
+          <div className="alert alert-warning min-w-0 items-start text-sm">
+            <div className="min-w-0">
               <p className="font-semibold">Execution-time price re-check required</p>
               <p>
                 This acknowledgement is required, but the current UI does not read a live oracle. A deployed factory or

--- a/infra/alchemy/alchemy.run.ts
+++ b/infra/alchemy/alchemy.run.ts
@@ -4,6 +4,7 @@ import * as Output from "alchemy/Output"
 import * as Effect from "effect/Effect"
 
 const configured = (primary: string, legacy: string): string => process.env[primary] ?? process.env[legacy] ?? ""
+const configuredNonEmpty = (name: string, fallback: string): string => process.env[name]?.trim() || fallback
 
 const environmentForStage = (stage: string): string => {
   if (stage === "dev" || stage.startsWith("dev_")) return "development"
@@ -32,9 +33,12 @@ export default Alchemy.Stack(
       CHAIN_ID: process.env.CHAIN_ID ?? "11155111",
       ENVIRONMENT: process.env.ENVIRONMENT ?? environmentForStage(stage),
       RPC_URL: process.env.RPC_URL ?? "",
-      SIWE_DOMAIN: process.env.SIWE_DOMAIN ?? new URL(webOrigin).host,
-      SIWE_URI: process.env.SIWE_URI ?? webOrigin,
-      CORS_ORIGINS: process.env.CORS_ORIGINS ?? ["http://localhost:3000", "https://aetherdex.io", webOrigin].join(","),
+      SIWE_DOMAIN: configuredNonEmpty("SIWE_DOMAIN", new URL(webOrigin).host),
+      SIWE_URI: configuredNonEmpty("SIWE_URI", webOrigin),
+      CORS_ORIGINS: configuredNonEmpty(
+        "CORS_ORIGINS",
+        ["http://localhost:3000", "https://aetherdex.io", webOrigin].join(","),
+      ),
       AETHER_HOOK_ADDRESS: configured("AETHERDEX_HOOK", "AETHER_HOOK_ADDRESS"),
       TREASURY_ADDRESS: configured("AETHERDEX_TREASURY", "TREASURY_ADDRESS"),
       ROUTER_ADDRESS: configured("AETHERDEX_ROUTER", "ROUTER_ADDRESS"),

--- a/infra/alchemy/package.json
+++ b/infra/alchemy/package.json
@@ -9,7 +9,7 @@
     "deploy:dev": "alchemy deploy --stage dev_$USER --adopt --yes",
     "deploy:staging": "alchemy deploy --stage staging --adopt --yes",
     "web:build": "cd ../../apps/web && bun run build",
-    "web:deploy:dev": "test -n \"$VITE_API_URL\" && test -n \"$VITE_REOWN_PROJECT_ID\" && USER_SUFFIX=$(printf '%s' \"${USER:-default}\" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/^$/default/; s/^(.{1,45}).*$/\\1/') && cd ../../apps/web && VITE_API_URL=\"$VITE_API_URL\" VITE_REOWN_PROJECT_ID=\"$VITE_REOWN_PROJECT_ID\" VITE_WS_URL=\"$VITE_WS_URL\" bun run build && bunx wrangler pages deploy dist --project-name \"aetherdex-web-dev-$USER_SUFFIX\" --branch dev --commit-dirty=true",
+    "web:deploy:dev": "test -n \"$VITE_API_URL\" && test -n \"$VITE_REOWN_PROJECT_ID\" && test -n \"$USER\" && STAGE_SUFFIX=$(printf '%s' \"dev_$USER\" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9-]/-/g; s/^-+|-+$//g') && STAGE_SUFFIX=\"${STAGE_SUFFIX:0:45}\" && cd ../../apps/web && VITE_API_URL=\"$VITE_API_URL\" VITE_REOWN_PROJECT_ID=\"$VITE_REOWN_PROJECT_ID\" VITE_WS_URL=\"$VITE_WS_URL\" bun run build && bunx wrangler pages deploy dist --project-name \"aetherdex-web-$STAGE_SUFFIX\" --branch dev --commit-dirty=true",
     "web:deploy:staging": "test -n \"$VITE_API_URL\" && test -n \"$VITE_REOWN_PROJECT_ID\" && cd ../../apps/web && VITE_API_URL=\"$VITE_API_URL\" VITE_REOWN_PROJECT_ID=\"$VITE_REOWN_PROJECT_ID\" VITE_WS_URL=\"$VITE_WS_URL\" bun run build && bunx wrangler pages deploy dist --project-name aetherdex-web-staging --branch main --commit-dirty=true",
     "destroy:dev": "alchemy destroy --stage dev_$USER"
   },

--- a/infra/alchemy/package.json
+++ b/infra/alchemy/package.json
@@ -9,7 +9,7 @@
     "deploy:dev": "alchemy deploy --stage dev_$USER --adopt --yes",
     "deploy:staging": "alchemy deploy --stage staging --adopt --yes",
     "web:build": "cd ../../apps/web && bun run build",
-    "web:deploy:dev": "test -n \"$VITE_API_URL\" && test -n \"$VITE_REOWN_PROJECT_ID\" && test -n \"$USER\" && cd ../../apps/web && VITE_API_URL=\"$VITE_API_URL\" VITE_REOWN_PROJECT_ID=\"$VITE_REOWN_PROJECT_ID\" VITE_WS_URL=\"$VITE_WS_URL\" bun run build && bunx wrangler pages deploy dist --project-name \"aetherdex-web-dev-$USER\" --branch dev --commit-dirty=true",
+    "web:deploy:dev": "test -n \"$VITE_API_URL\" && test -n \"$VITE_REOWN_PROJECT_ID\" && USER_SUFFIX=$(printf '%s' \"${USER:-default}\" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/^$/default/; s/^(.{1,45}).*$/\\1/') && cd ../../apps/web && VITE_API_URL=\"$VITE_API_URL\" VITE_REOWN_PROJECT_ID=\"$VITE_REOWN_PROJECT_ID\" VITE_WS_URL=\"$VITE_WS_URL\" bun run build && bunx wrangler pages deploy dist --project-name \"aetherdex-web-dev-$USER_SUFFIX\" --branch dev --commit-dirty=true",
     "web:deploy:staging": "test -n \"$VITE_API_URL\" && test -n \"$VITE_REOWN_PROJECT_ID\" && cd ../../apps/web && VITE_API_URL=\"$VITE_API_URL\" VITE_REOWN_PROJECT_ID=\"$VITE_REOWN_PROJECT_ID\" VITE_WS_URL=\"$VITE_WS_URL\" bun run build && bunx wrangler pages deploy dist --project-name aetherdex-web-staging --branch main --commit-dirty=true",
     "destroy:dev": "alchemy destroy --stage dev_$USER"
   },

--- a/infra/alchemy/package.json
+++ b/infra/alchemy/package.json
@@ -9,7 +9,7 @@
     "deploy:dev": "alchemy deploy --stage dev_$USER --adopt --yes",
     "deploy:staging": "alchemy deploy --stage staging --adopt --yes",
     "web:build": "cd ../../apps/web && bun run build",
-    "web:deploy:dev": "test -n \"$VITE_API_URL\" && test -n \"$VITE_REOWN_PROJECT_ID\" && cd ../../apps/web && VITE_API_URL=\"$VITE_API_URL\" VITE_REOWN_PROJECT_ID=\"$VITE_REOWN_PROJECT_ID\" VITE_WS_URL=\"$VITE_WS_URL\" bun run build && bunx wrangler pages deploy dist --project-name aetherdex-web-dev --branch dev --commit-dirty=true",
+    "web:deploy:dev": "test -n \"$VITE_API_URL\" && test -n \"$VITE_REOWN_PROJECT_ID\" && test -n \"$USER\" && cd ../../apps/web && VITE_API_URL=\"$VITE_API_URL\" VITE_REOWN_PROJECT_ID=\"$VITE_REOWN_PROJECT_ID\" VITE_WS_URL=\"$VITE_WS_URL\" bun run build && bunx wrangler pages deploy dist --project-name \"aetherdex-web-dev-$USER\" --branch dev --commit-dirty=true",
     "web:deploy:staging": "test -n \"$VITE_API_URL\" && test -n \"$VITE_REOWN_PROJECT_ID\" && cd ../../apps/web && VITE_API_URL=\"$VITE_API_URL\" VITE_REOWN_PROJECT_ID=\"$VITE_REOWN_PROJECT_ID\" VITE_WS_URL=\"$VITE_WS_URL\" bun run build && bunx wrangler pages deploy dist --project-name aetherdex-web-staging --branch main --commit-dirty=true",
     "destroy:dev": "alchemy destroy --stage dev_$USER"
   },

--- a/packages/contracts/script/Verify.s.sol
+++ b/packages/contracts/script/Verify.s.sol
@@ -57,6 +57,7 @@ contract Verify is Script {
         require(expectedTreasury != address(0), "Verify: AETHERDEX_TREASURY must be set");
         require(router.code.length != 0, "Verify: router address must contain deployed code");
         require(hook.code.length != 0, "Verify: hook address must contain deployed code");
+        require(expectedTreasury.code.length != 0, "Verify: treasury address must contain deployed multisig code");
 
         console.log("\n=== AetherDEX Phase-4 Verification (#314) ===");
         console.log("Router:", router);

--- a/packages/contracts/script/Verify.s.sol
+++ b/packages/contracts/script/Verify.s.sol
@@ -57,7 +57,7 @@ contract Verify is Script {
         require(expectedTreasury != address(0), "Verify: AETHERDEX_TREASURY must be set");
         require(router.code.length != 0, "Verify: router address must contain deployed code");
         require(hook.code.length != 0, "Verify: hook address must contain deployed code");
-        require(expectedTreasury.code.length != 0, "Verify: treasury address must contain deployed multisig code");
+        require(expectedTreasury.code.length != 0, "Verify: treasury address must contain deployed code");
 
         console.log("\n=== AetherDEX Phase-4 Verification (#314) ===");
         console.log("Router:", router);


### PR DESCRIPTION
Follow-up to merged PR #317.

- prevent narrow `/pools/new` overflow in the responsive shell
- reject blank SIWE/CORS deployment values
- target the user-suffixed dev Pages project
- fall back safely when VITE_WS_URL is blank
- require deployed treasury code in verification

Validated locally with Biome, API/Alchemy TypeScript checks, frontend build, responsive checks, and Foundry tests.

## Summary by Sourcery

Tighten deployment and verification safeguards while addressing remaining UI and config edge cases for phase 4.

Bug Fixes:
- Prevent horizontal overflow on the new pool creation flow and root layout by constraining container minimum widths and clipping overflow.
- Handle blank websocket and API configuration values by trimming env vars and falling back to sensible defaults.
- Avoid accepting empty SIWE and CORS configuration values by enforcing non-empty environment variables.
- Ensure the deployed treasury address actually contains multisig code during verification.

Enhancements:
- Improve resilience of environment-based configuration for SIWE, CORS, and websocket origins by centralizing non-empty env resolution.

Build:
- Update the dev web deployment script to require a USER variable and deploy to a user-suffixed Cloudflare Pages project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page layout behavior to prevent horizontal overflow across the app.
  * Corrected handling of blank or whitespace-only configuration values for WebSocket, API, authentication, and CORS settings.
  * Added validation to ensure the configured treasury address contains deployed code.

* **Chores**
  * Development web deployments now use sanitized, user-specific project names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->