### PR TITLE
fix: verify TP SL creation event mappings

### DIFF
--- a/apps/api/migrations/0008_tp_sl_onchain_order_id.sql
+++ b/apps/api/migrations/0008_tp_sl_onchain_order_id.sql
@@ -1,4 +1,4 @@
 ALTER TABLE tp_sl_orders ADD COLUMN onchain_order_id TEXT;
 
-CREATE UNIQUE INDEX idx_tp_sl_orders_chain_onchain_id
+CREATE INDEX idx_tp_sl_orders_chain_onchain_id
   ON tp_sl_orders(chain_id, onchain_order_id);

--- a/apps/api/migrations/0008_tp_sl_onchain_order_id.sql
+++ b/apps/api/migrations/0008_tp_sl_onchain_order_id.sql
@@ -1,4 +1,4 @@
 ALTER TABLE tp_sl_orders ADD COLUMN onchain_order_id TEXT;
 
-CREATE INDEX idx_tp_sl_orders_chain_onchain_id
+CREATE UNIQUE INDEX idx_tp_sl_orders_chain_onchain_id
   ON tp_sl_orders(chain_id, onchain_order_id);

--- a/apps/api/migrations/0009_unique_tp_sl_onchain_order_id.sql
+++ b/apps/api/migrations/0009_unique_tp_sl_onchain_order_id.sql
@@ -1,4 +1,20 @@
 DROP INDEX IF EXISTS idx_tp_sl_orders_chain_onchain_id;
 
+DELETE FROM tp_sl_orders
+WHERE id IN (
+  SELECT id
+  FROM (
+    SELECT
+      id,
+      ROW_NUMBER() OVER (
+        PARTITION BY chain_id, onchain_order_id
+        ORDER BY id
+      ) AS duplicate_rank
+    FROM tp_sl_orders
+    WHERE onchain_order_id IS NOT NULL
+  )
+  WHERE duplicate_rank > 1
+);
+
 CREATE UNIQUE INDEX idx_tp_sl_orders_chain_onchain_id
   ON tp_sl_orders(chain_id, onchain_order_id);

--- a/apps/api/migrations/0009_unique_tp_sl_onchain_order_id.sql
+++ b/apps/api/migrations/0009_unique_tp_sl_onchain_order_id.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_tp_sl_orders_chain_onchain_id;
+
+CREATE UNIQUE INDEX idx_tp_sl_orders_chain_onchain_id
+  ON tp_sl_orders(chain_id, onchain_order_id);

--- a/apps/api/migrations/0009_unique_tp_sl_onchain_order_id.sql
+++ b/apps/api/migrations/0009_unique_tp_sl_onchain_order_id.sql
@@ -1,5 +1,23 @@
 DROP INDEX IF EXISTS idx_tp_sl_orders_chain_onchain_id;
 
+WITH duplicate_map AS (
+  SELECT duplicate.id AS duplicate_id, MIN(retained.id) AS retained_id
+  FROM tp_sl_orders AS duplicate
+  JOIN tp_sl_orders AS retained
+    ON retained.chain_id = duplicate.chain_id
+    AND retained.onchain_order_id = duplicate.onchain_order_id
+    AND retained.id < duplicate.id
+  WHERE duplicate.onchain_order_id IS NOT NULL
+  GROUP BY duplicate.id
+)
+UPDATE keeper_executions
+SET order_id = (
+  SELECT retained_id
+  FROM duplicate_map
+  WHERE duplicate_id = keeper_executions.order_id
+)
+WHERE order_id IN (SELECT duplicate_id FROM duplicate_map);
+
 DELETE FROM tp_sl_orders
 WHERE id IN (
   SELECT id

--- a/apps/api/src/routes/tp-sl.ts
+++ b/apps/api/src/routes/tp-sl.ts
@@ -174,6 +174,9 @@ tpSl.post("/orders", requireAuth, async (c) => {
       return c.json({ error: "TPSL_ADDRESS and RPC_URL are required to verify creationTxHash" }, 503)
     }
     const publicClient = createPublicClient({ transport: http(c.env.RPC_URL) })
+    if ((await publicClient.getChainId()) !== chainIdFor(c)) {
+      return c.json({ error: "RPC_URL chain does not match CHAIN_ID" }, 503)
+    }
     const receipt = await publicClient.getTransactionReceipt({
       hash: body.creationTxHash as `0x${string}`,
     })

--- a/apps/api/src/routes/tp-sl.ts
+++ b/apps/api/src/routes/tp-sl.ts
@@ -11,6 +11,7 @@
 
 import { Effect, Layer } from "effect"
 import { Hono } from "hono"
+import { createPublicClient, decodeEventLog, getAddress, http, isAddress } from "viem"
 import { type AuthVariables, requireAuth } from "../auth/middleware"
 import { makeDbLayer } from "../db/client"
 import { runEffect } from "../lib/effect-bridge"
@@ -23,6 +24,9 @@ type Bindings = {
   STORAGE: R2Bucket
   CHAIN_ID: string
   ENVIRONMENT: string
+  RPC_URL?: string
+  TPSL_ADDRESS?: string
+  AETHER_TPSL_ADDRESS?: string
 }
 
 const tpSl = new Hono<{ Bindings: Bindings; Variables: AuthVariables }>()
@@ -31,6 +35,22 @@ const tpSlLayer = (db: D1Database) => TpSlServiceLive.pipe(Layer.provide(makeDbL
 const chainIdFor = (c: { env: Bindings }) => Number.parseInt(c.env.CHAIN_ID, 10) || 11155111
 const poolIdPattern = /^0x[a-fA-F0-9]{64}$/
 const uintPattern = /^[0-9]+$/
+const transactionHashPattern = /^0x[a-fA-F0-9]{64}$/
+const ORDER_CREATED_ABI = [
+  {
+    type: "event",
+    name: "OrderCreated",
+    inputs: [
+      { indexed: true, name: "orderId", type: "uint256" },
+      { indexed: true, name: "owner", type: "address" },
+      { indexed: false, name: "orderType", type: "uint8" },
+      { indexed: true, name: "poolId", type: "bytes32" },
+      { indexed: false, name: "zeroForOne", type: "bool" },
+      { indexed: false, name: "amountIn", type: "uint128" },
+      { indexed: false, name: "triggerPriceX18", type: "uint256" },
+    ],
+  },
+] as const
 
 // ─── POST /api/v1/tp-sl/orders ─────────────────────────────────────────────
 
@@ -48,7 +68,7 @@ tpSl.post("/orders", requireAuth, async (c) => {
     twapWindow?: number
     slippageBps?: number
     deadline?: number
-    onchainOrderId?: string
+    creationTxHash?: string
   }>()
 
   if (
@@ -61,12 +81,12 @@ tpSl.post("/orders", requireAuth, async (c) => {
     !body.twapWindow ||
     body.slippageBps === undefined ||
     !body.deadline ||
-    !body.onchainOrderId
+    !body.creationTxHash
   ) {
     return c.json(
       {
         error:
-          "poolId, orderType, zeroForOne, amountIn, minAmountOut, triggerPriceX18, twapWindow, slippageBps, deadline, onchainOrderId required",
+          "poolId, orderType, zeroForOne, amountIn, minAmountOut, triggerPriceX18, twapWindow, slippageBps, deadline, creationTxHash required",
       },
       400,
     )
@@ -86,7 +106,7 @@ tpSl.post("/orders", requireAuth, async (c) => {
     !Number.isFinite(body.deadline) ||
     !Number.isInteger(body.deadline) ||
     body.deadline <= Date.now() ||
-    !uintPattern.test(body.onchainOrderId)
+    !transactionHashPattern.test(body.creationTxHash)
   ) {
     return c.json({ error: "Invalid TP/SL order values" }, 400)
   }
@@ -104,20 +124,42 @@ tpSl.post("/orders", requireAuth, async (c) => {
   }
 
   // At this point all fields are validated as present
-  const {
-    poolId,
-    orderType,
-    zeroForOne,
-    amountIn,
-    minAmountOut,
-    triggerPriceX18,
-    twapWindow,
-    slippageBps,
-    deadline,
-    onchainOrderId,
-  } = body
+  const { poolId, orderType, zeroForOne, amountIn, minAmountOut, triggerPriceX18, twapWindow, slippageBps, deadline } =
+    body
 
   try {
+    const tpslAddress = bodyAddress(c.env.TPSL_ADDRESS) ?? bodyAddress(c.env.AETHER_TPSL_ADDRESS)
+    if (!tpslAddress || !c.env.RPC_URL) {
+      return c.json({ error: "TPSL_ADDRESS and RPC_URL are required to verify creationTxHash" }, 503)
+    }
+    const receipt = await createPublicClient({ transport: http(c.env.RPC_URL) }).getTransactionReceipt({
+      hash: body.creationTxHash as `0x${string}`,
+    })
+    if (receipt.status !== "success") return c.json({ error: "creationTxHash transaction reverted" }, 400)
+    const event = receipt.logs
+      .filter((log) => log.address.toLowerCase() === tpslAddress.toLowerCase())
+      .map((log) => {
+        try {
+          return decodeEventLog({ abi: ORDER_CREATED_ABI, data: log.data, topics: log.topics })
+        } catch {
+          return null
+        }
+      })
+      .find((decoded) => decoded?.eventName === "OrderCreated")
+    if (!event || event.eventName !== "OrderCreated") return c.json({ error: "No valid OrderCreated event found" }, 400)
+    const eventArgs = event.args
+    const expectedType = orderType === "take_profit" ? 0 : 1
+    if (
+      eventArgs.owner.toLowerCase() !== session.userAddress.toLowerCase() ||
+      eventArgs.poolId.toLowerCase() !== poolId.toLowerCase() ||
+      eventArgs.orderType !== expectedType ||
+      eventArgs.zeroForOne !== zeroForOne ||
+      eventArgs.amountIn.toString() !== amountIn ||
+      eventArgs.triggerPriceX18.toString() !== triggerPriceX18
+    ) {
+      return c.json({ error: "OrderCreated event does not match the requested TP/SL order" }, 400)
+    }
+    const onchainOrderId = eventArgs.orderId.toString()
     const program = Effect.gen(function* () {
       const tpSlService = yield* TpSlService
       return yield* tpSlService.createOrder({
@@ -142,6 +184,11 @@ tpSl.post("/orders", requireAuth, async (c) => {
     return c.json({ error: String(err) }, 500)
   }
 })
+
+function bodyAddress(value: string | undefined): `0x${string}` | null {
+  if (!value || !isAddress(value)) return null
+  return getAddress(value)
+}
 
 // ─── GET /api/v1/tp-sl/orders/:id ───────────────────────────────────────────
 

--- a/apps/api/src/routes/tp-sl.ts
+++ b/apps/api/src/routes/tp-sl.ts
@@ -220,7 +220,7 @@ tpSl.post("/orders", requireAuth, async (c) => {
       onchainOrder.triggerPriceX18.toString() !== triggerPriceX18 ||
       Number(onchainOrder.twapWindow) !== twapWindow ||
       onchainOrder.slippageBps.toString() !== String(slippageBps) ||
-      onchainOrder.deadline * 1000n !== BigInt(deadline) ||
+      onchainOrder.deadline !== BigInt(Math.floor(deadline / 1000)) ||
       onchainOrder.status !== 0
     ) {
       return c.json({ error: "On-chain TP/SL order does not match the requested parameters" }, 400)

--- a/apps/api/src/routes/tp-sl.ts
+++ b/apps/api/src/routes/tp-sl.ts
@@ -52,6 +52,47 @@ const ORDER_CREATED_ABI = [
   },
 ] as const
 
+const TPSL_ORDER_ABI = [
+  {
+    type: "function",
+    name: "getOrder",
+    stateMutability: "view",
+    inputs: [{ name: "orderId", type: "uint256" }],
+    outputs: [
+      {
+        name: "order",
+        type: "tuple",
+        components: [
+          { name: "id", type: "uint256" },
+          { name: "owner", type: "address" },
+          { name: "orderType", type: "uint8" },
+          {
+            name: "poolKey",
+            type: "tuple",
+            components: [
+              { name: "currency0", type: "address" },
+              { name: "currency1", type: "address" },
+              { name: "fee", type: "uint24" },
+              { name: "tickSpacing", type: "int24" },
+              { name: "hooks", type: "address" },
+            ],
+          },
+          { name: "zeroForOne", type: "bool" },
+          { name: "amountIn", type: "uint128" },
+          { name: "minAmountOut", type: "uint128" },
+          { name: "triggerPriceX18", type: "uint256" },
+          { name: "twapWindow", type: "uint32" },
+          { name: "slippageBps", type: "uint256" },
+          { name: "deadline", type: "uint256" },
+          { name: "status", type: "uint8" },
+          { name: "createdAt", type: "uint256" },
+          { name: "executedAt", type: "uint256" },
+        ],
+      },
+    ],
+  },
+] as const
+
 // ─── POST /api/v1/tp-sl/orders ─────────────────────────────────────────────
 
 tpSl.post("/orders", requireAuth, async (c) => {
@@ -132,7 +173,8 @@ tpSl.post("/orders", requireAuth, async (c) => {
     if (!tpslAddress || !c.env.RPC_URL) {
       return c.json({ error: "TPSL_ADDRESS and RPC_URL are required to verify creationTxHash" }, 503)
     }
-    const receipt = await createPublicClient({ transport: http(c.env.RPC_URL) }).getTransactionReceipt({
+    const publicClient = createPublicClient({ transport: http(c.env.RPC_URL) })
+    const receipt = await publicClient.getTransactionReceipt({
       hash: body.creationTxHash as `0x${string}`,
     })
     if (receipt.status !== "success") return c.json({ error: "creationTxHash transaction reverted" }, 400)
@@ -158,6 +200,27 @@ tpSl.post("/orders", requireAuth, async (c) => {
       eventArgs.triggerPriceX18.toString() !== triggerPriceX18
     ) {
       return c.json({ error: "OrderCreated event does not match the requested TP/SL order" }, 400)
+    }
+    const onchainOrder = await publicClient.readContract({
+      address: tpslAddress,
+      abi: TPSL_ORDER_ABI,
+      functionName: "getOrder",
+      args: [eventArgs.orderId],
+    })
+    if (
+      onchainOrder.id !== eventArgs.orderId ||
+      onchainOrder.owner.toLowerCase() !== session.userAddress.toLowerCase() ||
+      onchainOrder.orderType !== expectedType ||
+      onchainOrder.zeroForOne !== zeroForOne ||
+      onchainOrder.amountIn.toString() !== amountIn ||
+      onchainOrder.minAmountOut.toString() !== minAmountOut ||
+      onchainOrder.triggerPriceX18.toString() !== triggerPriceX18 ||
+      Number(onchainOrder.twapWindow) !== twapWindow ||
+      onchainOrder.slippageBps.toString() !== String(slippageBps) ||
+      onchainOrder.deadline * 1000n !== BigInt(deadline) ||
+      onchainOrder.status !== 0
+    ) {
+      return c.json({ error: "On-chain TP/SL order does not match the requested parameters" }, 400)
     }
     const onchainOrderId = eventArgs.orderId.toString()
     const program = Effect.gen(function* () {


### PR DESCRIPTION
Follow-up to merged PR #318.

- derive `onchainOrderId` from a verified `OrderCreated` receipt event
- match owner, pool, direction, type, amount, and trigger price
- enforce chain-scoped uniqueness for the stored on-chain order ID

Validated with API TypeScript, Biome, and the focused keeper suites (45 tests).

## Summary by Sourcery

Verify TP/SL orders against on-chain OrderCreated events and enforce unique on-chain order IDs per chain.

Bug Fixes:
- Validate TP/SL order creation by deriving the on-chain order ID from a matching OrderCreated event in the transaction receipt instead of trusting client input.
- Reject TP/SL orders when the on-chain OrderCreated event does not match the requested parameters or the creation transaction reverted.
- Enforce chain-scoped uniqueness of on-chain order IDs at the database level to prevent duplicates.

Enhancements:
- Require RPC and TPSL contract configuration to be present for TP/SL order verification and normalize contract addresses from environment variables.